### PR TITLE
Add SPI Flash to MuC and HSB

### DIFF
--- a/contrib/loaders/flash/hsbspi.S
+++ b/contrib/loaders/flash/hsbspi.S
@@ -1,0 +1,144 @@
+/***************************************************************************
+ *   Copyright (C) 2016 Motorola Mobility LLC                              *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.           *
+ ***************************************************************************/
+
+    .text
+    .syntax unified
+    .cpu cortex-m3
+    .thumb
+    .thumb_func
+/*
+ * To assemble:
+ *   arm-none-eabi-gcc -mcpu=cortex-m3 -mthumb -c contrib/loaders/flash/hsbspi.S
+ *   tools/asm_to_c.pl hsbspi.o 0
+ *   Copy the output into the correct source file.
+ */
+
+/* ES3 SPI Registers. */
+#define HSBSPI_CTRL0                                0x0000
+#define HSBSPI_CTRL0_DFS32_POS                      16
+#define HSBSPI_CTRL0_DFS32_MSK                      (0x1f<<HSBSPI_CTRL0_DFS32_POS)
+#define HSBSPI_CTRL0_DFS32(x)                       (((x-1)&0x1f)<<HSBSPI_CTRL0_DFS32_POS)
+#define HSBSPI_CTRL0_CFS_POS                        12
+#define HSBSPI_CTRL0_CFS_MSK                        (0x0f<<HSBSPI_CTRL0_CFS_POS)
+#define HSBSPI_CTRL0_TMOD_POS                       8
+#define HSBSPI_CTRL0_TMOD_MSK                       (0x03<<HSBSPI_CTRL0_TMOD_POS)
+#define HSBSPI_CTRL0_TMOD_TX_RX                     (0x00<<HSBSPI_CTRL0_TMOD_POS)
+#define HSBSPI_CTRL0_SCPOL_POS                      7
+#define HSBSPI_CTRL0_SCPOL_MSK                      (0x01<<HSBSPI_CTRL0_SCPOL_POS)
+#define HSBSPI_CTRL0_SCPH_POS                       6
+#define HSBSPI_CTRL0_SCPH_MSK                       (0x01<<HSBSPI_CTRL0_SCPH_POS)
+#define HSBSPI_CTRL0_FRF_POS                        4
+#define HSBSPI_CTRL0_FRF_MSK                        (0x03<<HSBSPI_CTRL0_FRF_POS)
+#define HSBSPI_CTRL0_FRF_MOTSPI                     (0x00<<HSBSPI_CTRL0_FRF_POS)
+
+#define HSBSPI_CTRL1                                0x0004
+#define HSBSPI_CTRL1_NDF_POS                        0
+#define HSBSPI_CTRL1_NDF_MSK                        (0xffff<<HSBSPI_CTRL0_NDF_POS)
+
+#define HSBSPI_SSIENR                               0x0008
+#define HSBSPI_SSIENR_SSI_EN_POS                    0
+#define HSBSPI_SSIENR_SSI_EN_MSK                    (1<<HSBSPI_SSIENR_SSI_EN_POS)
+
+#define HSBSPI_SER                                  0x0010
+#define HSBSPI_SER_POS                              0
+#define HSBSPI_SER_MSK                              (0x3<<HSBSPI_SER_POS)
+
+#define HSBSPI_BAUDR                                0x0014
+#define HSBSPI_BAUDR_POS                            0
+#define HSBSPI_BAUDR_MSK                            (0xffff<<HSBSPI_BAUDR_POS)
+
+#define HSBSPI_IMR                                  0x002c
+
+#define HSBSPI_SR                                   0x0028
+#define HSBSPI_SR_DCOL_POS                          6
+#define HSBSPI_SR_DCOL_MSK                          (0x01<<HSBSPI_SR_DCOL_POS)
+#define HSBSPI_SR_RFF_POS                           4
+#define HSBSPI_SR_RFF_MSK                           (0x01<<HSBSPI_SR_RFF_POS)
+#define HSBSPI_SR_RFNE_POS                          3
+#define HSBSPI_SR_RFNE_MSK                          (0x01<<HSBSPI_SR_RFNE_POS)
+#define HSBSPI_SR_TFE_POS                           2
+#define HSBSPI_SR_TFE_MSK                           (0x01<<HSBSPI_SR_TFE_POS)
+#define HSBSPI_SR_TFNF_POS                          1
+#define HSBSPI_SR_TFNF_MSK                          (0x01<<HSBSPI_SR_TFNF_POS)
+#define HSBSPI_SR_BUSY_POS                          0
+#define HSBSPI_SR_BUSY_MSK                          (0x01<<HSBSPI_SR_BUSY_POS)
+
+#define HSBSPI_DR0                                  0x0060
+#define HSBSPI_DR0_POS                              0
+#define HSBSPI_DR0_MSK                              (0xffffffff<<HSBSPI_DR0_POS)
+
+/*
+ * Params:
+ *   r0 - workarea start
+ *   r1 - tx count (bytes)
+ *   r2 - SPI Register base address
+ * Clobbered:
+ *   r4 - rx pointer
+ *   r5 - rx count
+ *   r6 - tmp (status register)
+ *   r7 - tmp (copy)
+ */
+
+hsbspi_flash:
+    cbz     r1,done
+
+    /* Setup and enable the SPI. */
+    ldr     r6,spi_ctrl_0
+    str     r6,[r2,#HSBSPI_CTRL0]
+    mov     r6,#0
+    str     r6,[r2,HSBSPI_IMR]
+    ldr     r6,[r2,#HSBSPI_SSIENR]
+    orr     r6,r6,#HSBSPI_SSIENR_SSI_EN_MSK
+    str     r6,[r2,#HSBSPI_SSIENR]
+
+    mov     r4,r0
+    mov     r5,r1
+
+copy_tx_bytes:
+    cbz     r1,copy_rx_bytes
+    ldr     r6,[r2,#HSBSPI_SR]
+    tst     r6,#HSBSPI_SR_TFNF_MSK
+    ittt    ne
+    ldrbne  r7,[r0],#1
+    strne   r7,[r2,#HSBSPI_DR0]
+    subne   r1,r1,#1
+
+copy_rx_bytes:
+    cbz     r5,done
+    ldr     r6,[r2,#HSBSPI_SR]
+    tst     r6,#HSBSPI_SR_RFNE_MSK
+    ittt    ne
+    ldrne   r7,[r2,HSBSPI_DR0]
+    strbne  r7,[r4],#1
+    subne   r5,r5,#1
+    b       copy_tx_bytes
+
+    /* Place the constant data before the end so no special processing needs to
+       be done to calculate the address of the bkpt instruction.  For this it
+       needs to be the last instruction. */
+spi_ctrl_0:
+    .word    HSBSPI_CTRL0_DFS32(8) | HSBSPI_CTRL0_FRF_MOTSPI
+
+done:
+    /* Disable the SPI. */
+    ldr     r7,[r2,#HSBSPI_SSIENR]
+    bic     r7,#HSBSPI_SSIENR_SSI_EN_MSK
+    str     r7,[r2,#HSBSPI_SSIENR]
+    bkpt    #0
+

--- a/contrib/loaders/flash/stm32spi.S
+++ b/contrib/loaders/flash/stm32spi.S
@@ -1,0 +1,108 @@
+/***************************************************************************
+ *   Copyright (C) 2016 Motorola Mobility LLC                              *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.           *
+ ***************************************************************************/
+
+    .text
+    .syntax unified
+    .cpu cortex-m4
+    .thumb
+    .thumb_func
+/*
+ * To assemble:
+ *   arm-none-eabi-gcc -mcpu=cortex-m4 -mthumb -c contrib/loaders/flash/stm32spi.S
+ *   tools/asm_to_c.pl stm32spi.o 0
+ *   Copy the output into the correct source file.
+ */
+
+#define STM32SPI_CR1_OFS      0x00
+#define STM32SPI_CR1_SPE      (1<<6)
+#define STM32SPI_CR1_BR_POS   3
+#define STM32SPI_CR1_BR_MSK   (0x7<<STM32SPI_SPI_CR1_BR_POS)
+#define STM32SPI_CR1_MSTR     (1<<2)
+#define STM32SPI_CR1_CPOL     (1<<1)
+#define STM32SPI_CR1_CPHA     (1<<0)
+
+#define STM32SPI_CR2_OFS      0x04
+#define STM32SPI_CR2_DS_MSK   (0xf<<8)
+#define STM32SPI_CR2_DS_8BIT  (0x7<<8)
+#define STM32SPI_CR2_FRF      (1<<4)
+#define STM32SPI_CR2_SSOE     (1<<2)
+
+#define STM32SPI_SR_OFS        0x08
+#define STM32SPI_SR_FTLVL_MSK (0x3<<11)
+#define STM32SPI_SR_FRLVL_MSK (0x3<<9)
+#define STM32SPI_SR_BSY       (1<<7)
+#define STM32SPI_SR_TXE       (1<<1)
+#define STM32SPI_SR_RXNE      (1<<0)
+
+#define STM32SPI_DR_OFS       0x0c
+
+/*
+ * Params:
+ *   r0 - workarea start
+ *   r1 - tx count (bytes)
+ *   r2 - SPI Register base address
+ * Clobbered:
+ *   r4 - rx pointer
+ *   r5 - rx count
+ *   r6 - tmp (status register)
+ *   r7 - tmp (copy)
+ */
+
+stm32spi_flash:
+    cbz     r1,done
+
+    /* Enable the SPI. */
+    ldrh    r6,[r2,#STM32SPI_CR1_OFS]
+    orr     r6,r6,#STM32SPI_CR1_SPE
+    strh    r6,[r2,#STM32SPI_CR1_OFS]
+
+    mov     r4,r0
+    mov     r5,r1
+
+copy_tx_bytes:
+    cbz     r1,copy_rx_bytes
+    ldrh    r6,[r2,#STM32SPI_SR_OFS]
+    tst     r6,#STM32SPI_SR_TXE
+    ittt    ne
+    ldrbne  r7,[r0],#1
+    strbne  r7,[r2,#STM32SPI_DR_OFS]
+    subne   r1,r1,#1
+
+copy_rx_bytes:
+    cbz     r5,done
+    ldrh    r6,[r2,#STM32SPI_SR_OFS]
+    tst     r6,#STM32SPI_SR_RXNE
+    ittt    ne
+    ldrbne  r7,[r2,#STM32SPI_DR_OFS]
+    strbne  r7,[r4],#1
+    subne   r5,r5,#1
+    b       copy_tx_bytes
+
+done:
+    /* Wait until not busy. */
+    ldrh    r7,[r2,#STM32SPI_SR_OFS]
+    tst     r7,#STM32SPI_SR_BSY
+    bne     done
+
+    /* Disable the SPI. */
+    ldrh    r7,[r2,#STM32SPI_CR1_OFS]
+    bic     r7,#STM32SPI_CR1_SPE
+    strh    r7,[r2,#STM32SPI_CR1_OFS]
+    bkpt    #0
+

--- a/src/flash/nor/Makefile.am
+++ b/src/flash/nor/Makefile.am
@@ -25,6 +25,8 @@ NOR_DRIVERS = \
 	faux.c \
 	fm3.c \
 	fm4.c \
+	genspi.c \
+	hsbspi.c \
 	jtagspi.c \
 	kinetis.c \
 	kinetis_ke.c \
@@ -49,6 +51,7 @@ NOR_DRIVERS = \
 	stm32f2x.c \
 	stm32lx.c \
 	stm32l4x.c \
+	stm32spi.c \
 	str7x.c \
 	str9x.c \
 	str9xpec.c \

--- a/src/flash/nor/drivers.c
+++ b/src/flash/nor/drivers.c
@@ -1,6 +1,8 @@
 /***************************************************************************
  *   Copyright (C) 2009 Zachary T Welch <zw@superlucidity.net>             *
  *                                                                         *
+ *   Copyright (C) 2016 Motorola Mobility LLC                              *
+ *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
  *   the Free Software Foundation; either version 2 of the License, or     *
@@ -39,6 +41,7 @@ extern struct flash_driver em357_flash;
 extern struct flash_driver faux_flash;
 extern struct flash_driver fm3_flash;
 extern struct flash_driver fm4_flash;
+extern struct flash_driver hsbspi_flash;
 extern struct flash_driver jtagspi_flash;
 extern struct flash_driver kinetis_flash;
 extern struct flash_driver kinetis_ke_flash;
@@ -60,6 +63,7 @@ extern struct flash_driver stm32f1x_flash;
 extern struct flash_driver stm32f2x_flash;
 extern struct flash_driver stm32lx_flash;
 extern struct flash_driver stm32l4x_flash;
+extern struct flash_driver stm32spi_flash;
 extern struct flash_driver stmsmi_flash;
 extern struct flash_driver str7x_flash;
 extern struct flash_driver str9x_flash;
@@ -92,6 +96,7 @@ static struct flash_driver *flash_drivers[] = {
 	&fm3_flash,
 	&fm4_flash,
 	&jtagspi_flash,
+	&hsbspi_flash,
 	&kinetis_flash,
 	&kinetis_ke_flash,
 	&lpc2000_flash,
@@ -112,6 +117,7 @@ static struct flash_driver *flash_drivers[] = {
 	&stm32f2x_flash,
 	&stm32lx_flash,
 	&stm32l4x_flash,
+	&stm32spi_flash,
 	&stmsmi_flash,
 	&str7x_flash,
 	&str9x_flash,

--- a/src/flash/nor/genspi.c
+++ b/src/flash/nor/genspi.c
@@ -1,0 +1,485 @@
+/***************************************************************************
+ *   Copyright (C) 2016 Motorola Mobility LLC                              *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.           *
+ ***************************************************************************/
+/*
+ * Generic utilities used for SPI flash drivers.  To use this call probe with
+ * a time of generic function pointers.  This file will handle the generic
+ * parts of the communication with OpenOCD as well as the SPI flash.  The
+ * provided functions will be called when necessary.
+ *
+ * This was derived from mrlvqspi.c.
+ */
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include "genspi.h"
+
+#define CHIP_ERASE_TIMEOUT  (100)
+#define CHIP_STATUS_TIMEOUT (10)
+
+static int genspi_wait_busy(struct flash_bank *bank, unsigned int timeout)
+{
+	struct genspi_flash_bank *genspi_info = bank->driver_priv;
+	uint8_t cmd_buf[1];
+	uint8_t status[1];
+	int retval;
+
+	do {
+		cmd_buf[0] = SPIFLASH_READ_STATUS;
+		status[0] = 0x00;
+		retval = genspi_info->fops->spi_send_cmd(bank, cmd_buf, sizeof(cmd_buf), status, sizeof(status));
+		if (((status[0] & SPIFLASH_BSY_BIT) == 0) &&
+		    (retval == ERROR_OK)) {
+			return ERROR_OK;
+		}
+		alive_sleep(1);
+	} while (timeout-- > 0);
+	LOG_ERROR("Timed out waiting for busy.");
+	return ERROR_WAIT;
+}
+
+static int genspi_wait_write_enable(struct flash_bank *bank, unsigned int timeout)
+{
+	struct genspi_flash_bank *genspi_info = bank->driver_priv;
+	uint8_t cmd_buf[1];
+	uint8_t status[1];
+	int retval;
+
+	do {
+		cmd_buf[0] = SPIFLASH_READ_STATUS;
+		status[0] = 0x00;
+		retval = genspi_info->fops->spi_send_cmd(bank, cmd_buf, sizeof(cmd_buf), status, sizeof(status));
+		if (((status[0] & SPIFLASH_WE_BIT) != 0) &&
+		    (retval == ERROR_OK)) {
+			return ERROR_OK;
+		}
+		alive_sleep(1);
+	} while (timeout-- > 0);
+	LOG_ERROR("Timed out waiting for write enable.");
+	return ERROR_WAIT;
+}
+
+static int genspi_set_write_status(struct flash_bank *bank, bool mode)
+{
+	struct genspi_flash_bank *genspi_info = bank->driver_priv;
+	int retval;
+	uint8_t cmd_buf[1] = { SPIFLASH_WRITE_ENABLE };
+
+	if (!mode) {
+		cmd_buf[0] = SPIFLASH_WRITE_DISABLE;
+	}
+	retval = genspi_wait_busy(bank, CHIP_STATUS_TIMEOUT);
+	if (retval == ERROR_OK) {
+		retval = genspi_info->fops->spi_send_cmd(bank, cmd_buf, 1, NULL, 0);
+	}
+	if (retval == ERROR_OK) {
+		retval = genspi_wait_write_enable(bank, CHIP_STATUS_TIMEOUT);
+	}
+	return retval;
+}
+
+int genspi_flash_erase(struct flash_bank *bank, int first, int last)
+{
+	struct target *target = bank->target;
+	struct genspi_flash_bank *genspi_info = bank->driver_priv;
+	uint8_t cmd_buf[4];
+	int retval = ERROR_OK;
+	int sector;
+
+	LOG_DEBUG("Erase from sector %d to sector %d.", first, last);
+
+	if (target->state != TARGET_HALTED) {
+		LOG_ERROR("Target not halted.");
+		return ERROR_TARGET_NOT_HALTED;
+	}
+
+	if ((first < 0) || (last < first) || (last >= bank->num_sectors)) {
+		LOG_ERROR("Flash sector range invalid (%d-%d).", first, last);
+		return ERROR_FLASH_SECTOR_INVALID;
+	}
+
+	if (!(genspi_info->probed)) {
+		LOG_ERROR("Flash bank not probed.");
+		return ERROR_FLASH_BANK_NOT_PROBED;
+	}
+
+	for (sector = first; sector <= last; sector++) {
+		if (bank->sectors[sector].is_protected) {
+			LOG_ERROR("Flash sector %d protected.", sector);
+			return ERROR_FAIL;
+		}
+	}
+
+	/*
+	 * If we're erasing the entire chip and the flash supports
+	 * it, use a bulk erase instead of going sector-by-sector.
+	 */
+	if ((first == 0) && (last == (bank->num_sectors - 1)) &&
+	    (genspi_info->dev->chip_erase_cmd != genspi_info->dev->erase_cmd)) {
+		LOG_DEBUG("Chip supports the bulk erase command."\
+		" Will use bulk erase instead of sector-by-sector erase.");
+		/* Enable write access. */
+		retval = genspi_set_write_status(bank, true);
+		if (retval != ERROR_OK) {
+			LOG_ERROR("Unable to enable writes to flash part.");
+			return retval;
+		}
+		cmd_buf[0] = genspi_info->dev->chip_erase_cmd;
+		retval = genspi_info->fops->spi_send_cmd(bank, cmd_buf, 2, NULL, 0);
+		if (retval != ERROR_OK) {
+			LOG_ERROR("Unable to send bulk erase command to flash part.");
+			return retval;
+		}
+		retval = genspi_wait_busy(bank, CHIP_ERASE_TIMEOUT);
+		if (retval == ERROR_OK) {
+			return retval;
+		} else
+			LOG_WARNING("Bulk flash erase failed.  Falling back to sector-by-sector erase.");
+	}
+
+	for (sector = first; sector <= last; sector++) {
+		/* Enable write access. */
+		retval = genspi_set_write_status(bank, true);
+		if (retval != ERROR_OK) {
+			LOG_ERROR("Unable to enable writes to flash part.");
+			return retval;
+		}
+		cmd_buf[0] = genspi_info->dev->erase_cmd;
+		cmd_buf[1] = (bank->sectors[sector].offset >> 16) & 0xff;
+		cmd_buf[2] = (bank->sectors[sector].offset >> 8) & 0xff;
+		cmd_buf[3] = (bank->sectors[sector].offset >> 0) & 0xff;
+		LOG_DEBUG("Erasing %d bytes starting at 0x%08" PRIx32  ".", bank->sectors[sector].size, bank->sectors[sector].offset);
+		retval = genspi_info->fops->spi_send_cmd(bank, cmd_buf, sizeof(cmd_buf), NULL, 0);
+		if (retval != ERROR_OK) {
+			LOG_ERROR("Unable to send block erase command to flash part.");
+			return retval;
+		}
+		retval = genspi_wait_busy(bank, CHIP_ERASE_TIMEOUT);
+		if (retval != ERROR_OK) {
+			LOG_ERROR("Unable to erase block at address: %08" PRIx32, bank->sectors[sector].offset);
+			return retval;
+		}
+	}
+	retval = genspi_wait_busy(bank, CHIP_STATUS_TIMEOUT);
+	return retval;
+}
+
+int genspi_flash_write(struct flash_bank *bank, const uint8_t *buffer,
+                       uint32_t offset, uint32_t count)
+{
+	struct target *target = bank->target;
+	struct genspi_flash_bank *genspi_info = bank->driver_priv;
+	uint32_t bytes_written;
+	uint32_t chunk;
+	uint8_t cmd_buf[4];
+	int sector;
+	int retval;
+
+	LOG_DEBUG("offset=0x%08" PRIx32 " count=0x%08" PRIx32, offset, count);
+
+	if (target->state != TARGET_HALTED) {
+		LOG_ERROR("Target not halted.");
+		return ERROR_TARGET_NOT_HALTED;
+	}
+
+	if (!(genspi_info->probed)) {
+		LOG_ERROR("Flash bank not probed.");
+		return ERROR_FLASH_BANK_NOT_PROBED;
+	}
+
+	if (offset + count > genspi_info->dev->size_in_bytes) {
+		LOG_WARNING("Data goes past the last address.  Extra %lu bytes discarded.",
+		            count - genspi_info->dev->size_in_bytes);
+		count = genspi_info->dev->size_in_bytes - offset;
+	}
+
+	/* Check sector protection */
+	for (sector = 0; sector < bank->num_sectors; sector++) {
+		/*
+		 * Start offset in or before this sector?
+		 * End offset in or behind this sector?
+		 */
+		if ((offset < (bank->sectors[sector].offset + bank->sectors[sector].size)) &&
+		    ((offset + count - 1) >= bank->sectors[sector].offset) &&
+		    bank->sectors[sector].is_protected) {
+			LOG_ERROR("Flash sector %d protected.", sector);
+			return ERROR_FAIL;
+		}
+	}
+
+	/* Enable write access. */
+	retval = genspi_set_write_status(bank, true);
+	if (retval != ERROR_OK) {
+		return retval;
+	}
+
+    bytes_written = 0;
+    while (count) {
+		/* Enable write access. */
+		retval = genspi_set_write_status(bank, true);
+		if (retval != ERROR_OK) {
+			LOG_ERROR("Unable to enable writes to flash part.");
+			return retval;
+		}
+
+		/* Setup the command. */
+		cmd_buf[0] = SPIFLASH_PAGE_PROGRAM;
+
+		/* Setup the address. */
+		cmd_buf[1] = (offset >> 16) & 0xff;
+		cmd_buf[2] = (offset >> 8) & 0xff;
+		cmd_buf[3] = (offset >> 0) & 0xff;
+
+		/* Send the command and data.   This will trash the contents of buffer. */
+		/* TODO: Verify it is OK to trash the contents of buffer. */
+		chunk = genspi_info->fops->max_data_bytes;
+		if (chunk > genspi_info->dev->pagesize) {
+			chunk = genspi_info->dev->pagesize;
+		}
+		if (chunk > count) {
+			chunk = count;
+		}
+
+		retval = genspi_info->fops->spi_send_cmd(bank, cmd_buf, sizeof(cmd_buf), (uint8_t *)&buffer[bytes_written], chunk);
+		if (retval != ERROR_OK) {
+			LOG_ERROR("Unable to program page at address: 0x%08" PRIx32 ".", offset);
+			return retval;
+		}
+		bytes_written += chunk;
+		offset += chunk;
+		count -= chunk;
+	}
+	return genspi_wait_busy(bank, CHIP_ERASE_TIMEOUT);
+}
+
+int genspi_flash_read(struct flash_bank *bank, uint8_t *buffer,
+				      uint32_t offset, uint32_t count)
+{
+	struct target *target = bank->target;
+	struct genspi_flash_bank *genspi_info = bank->driver_priv;
+	uint32_t bytes_copied;
+	uint32_t chunk;
+	uint8_t cmd_buf[5];
+	int retval;
+
+	if (target->state != TARGET_HALTED) {
+		LOG_ERROR("Target not halted.");
+		return ERROR_TARGET_NOT_HALTED;
+	}
+
+	if (!(genspi_info->probed)) {
+		LOG_ERROR("Flash bank not probed.");
+		return ERROR_FLASH_BANK_NOT_PROBED;
+	}
+
+	retval = genspi_wait_busy(bank, CHIP_ERASE_TIMEOUT);
+	if (retval != ERROR_OK) {
+		LOG_ERROR("Busy check before read timed out.");
+		return retval;
+	}
+
+	bytes_copied = 0;
+	while (count)
+	{
+		/* Setup the command. */
+		cmd_buf[0] = SPIFLASH_FAST_READ;
+
+		/* Setup the address. */
+		cmd_buf[1] = (offset >> 16) & 0xff;
+		cmd_buf[2] = (offset >> 8) & 0xff;
+		cmd_buf[3] = (offset >> 0) & 0xff;
+
+		/* One dummy byte must be included before the data is read. */
+		cmd_buf[4] = 0x00;
+
+		/* Determine how many bytes to copy. */
+		chunk = genspi_info->fops->max_data_bytes;
+		if (chunk > count) {
+			chunk = count;
+		}
+		/* Send the command and get the response. */
+		memset(&buffer[bytes_copied], 0, chunk);
+		retval = genspi_info->fops->spi_send_cmd(bank, cmd_buf, sizeof(cmd_buf), &buffer[bytes_copied], chunk);
+		if (retval != ERROR_OK) {
+			LOG_ERROR("Unable to read data at address: 0x%08" PRIx32 ".", offset);
+			return retval;
+		}
+		bytes_copied += chunk;
+		offset += bytes_copied;
+		count -= chunk;
+	}
+	return ERROR_OK;
+}
+
+int genspi_probe(struct flash_bank *bank, const struct genspi_fops *fops)
+{
+	struct target *target = bank->target;
+	struct genspi_flash_bank *genspi_info = bank->driver_priv;
+	uint32_t id = 0;
+	int retval;
+	struct flash_sector *sectors;
+	uint8_t rx_buf[3];
+	uint8_t cmd_buf[1];
+
+	/* If we've already probed, we should be fine to skip this time. */
+	if (genspi_info->probed) {
+		return ERROR_OK;
+	}
+
+    if ((fops == NULL) ||
+        (fops->spi_send_cmd == NULL)) {
+        return ERROR_FLASH_OPER_UNSUPPORTED;
+	}
+
+	if (target->state != TARGET_HALTED) {
+		LOG_ERROR("Target not halted.");
+		return ERROR_TARGET_NOT_HALTED;
+	}
+
+    genspi_info->fops = fops;
+	genspi_info->bank_num = bank->bank_number;
+
+	if (fops->spi_init) {
+		retval = fops->spi_init(bank);
+		if (retval != ERROR_OK) {
+			return retval;
+		}
+	}
+
+	/* Read the flash JEDEC ID. */
+	memset(rx_buf, 0x00, sizeof(rx_buf));
+	cmd_buf[0] = SPIFLASH_READ_ID;
+    retval = fops->spi_send_cmd(bank, cmd_buf, 1, rx_buf, sizeof(rx_buf));
+	if (retval != ERROR_OK)
+		return retval;
+	LOG_DEBUG("ID is 0x%02" PRIx8 " 0x%02" PRIx8 " 0x%02" PRIx8,
+					rx_buf[0], rx_buf[1], rx_buf[2]);
+
+	id = rx_buf[2] << 16 | rx_buf[1] << 8 | rx_buf[0];
+
+	genspi_info->dev = NULL;
+	for (const struct flash_device *p = flash_devices; p->name ; p++)
+		if (p->device_id == id) {
+			genspi_info->dev = p;
+			break;
+		}
+
+	if (!genspi_info->dev) {
+		LOG_ERROR("Unknown flash device ID 0x%08" PRIx32, id);
+		return ERROR_FAIL;
+	}
+
+	LOG_INFO("Found flash device \'%s\' ID 0x%08" PRIx32,
+		genspi_info->dev->name, genspi_info->dev->device_id);
+
+	/* Set correct size value. */
+	bank->size = genspi_info->dev->size_in_bytes;
+
+	/* Create and fill sectors array. */
+	bank->num_sectors =
+		genspi_info->dev->size_in_bytes / genspi_info->dev->sectorsize;
+	sectors = malloc(sizeof(struct flash_sector) * bank->num_sectors);
+	if (sectors == NULL) {
+		LOG_ERROR("Insufficient memory.");
+		return ERROR_FAIL;
+	}
+
+	for (int sector = 0; sector < bank->num_sectors; sector++) {
+		sectors[sector].offset =
+				sector * genspi_info->dev->sectorsize;
+		sectors[sector].size = genspi_info->dev->sectorsize;
+		sectors[sector].is_erased = -1;
+		sectors[sector].is_protected = 0;
+	}
+
+	bank->sectors = sectors;
+	genspi_info->probed = 1;
+
+	return ERROR_OK;
+}
+
+int genspi_auto_probe(struct flash_bank *bank, const struct genspi_fops *fops)
+{
+	struct genspi_flash_bank *genspi_info = bank->driver_priv;
+
+	if (genspi_info->probed)
+		return ERROR_OK;
+	return genspi_probe(bank, fops);
+}
+
+int genspi_flash_erase_check(struct flash_bank *bank)
+{
+	/* Not implemented yet */
+	return ERROR_OK;
+}
+
+int genspi_protect_check(struct flash_bank *bank)
+{
+	/* Not implemented yet */
+	return ERROR_OK;
+}
+
+int genspi_get_info(struct flash_bank *bank, char *buf, int buf_size)
+{
+	struct genspi_flash_bank *genspi_info = bank->driver_priv;
+
+	if (!(genspi_info->probed)) {
+		snprintf(buf, buf_size,
+			"\nSPI flash bank not probed yet\n");
+		return ERROR_OK;
+	}
+
+	snprintf(buf, buf_size, "\nSPI flash information:\n"
+		"  Device \'%s\' ID 0x%08" PRIx32 "\n",
+		genspi_info->dev->name, genspi_info->dev->device_id);
+
+	return ERROR_OK;
+}
+
+__FLASH_BANK_COMMAND(genspi_flash_bank_command)
+{
+	struct genspi_flash_bank *genspi_info;
+
+	if (CMD_ARGC < 7)
+		return ERROR_COMMAND_SYNTAX_ERROR;
+
+	genspi_info = malloc(sizeof(struct genspi_flash_bank));
+	if (genspi_info == NULL) {
+		LOG_ERROR("insufficient memory");
+		return ERROR_FAIL;
+	}
+	memset(genspi_info, 0, sizeof(*genspi_info));
+	genspi_info->gpio_pin = -1;
+
+	/* Get SPI controller register map base address */
+	COMMAND_PARSE_NUMBER(u32, CMD_ARGV[6], genspi_info->reg_base);
+	bank->driver_priv = genspi_info;
+	genspi_info->probed = 0;
+	LOG_DEBUG("Flash setup with SPI register base address: 0x%08x", genspi_info->reg_base);
+	/* See if a GPIO was specified to use as Chip Select. */
+	if (CMD_ARGC > 7) {
+		COMMAND_PARSE_NUMBER(u32, CMD_ARGV[7], genspi_info->gpio_base);
+		COMMAND_PARSE_NUMBER(s32, CMD_ARGV[8], genspi_info->gpio_pin);
+		LOG_DEBUG("Flash Chip Select setup with base address: 0x%08x and pin %d",
+		          genspi_info->gpio_base, genspi_info->gpio_pin);
+	}
+
+	return ERROR_OK;
+}

--- a/src/flash/nor/genspi.h
+++ b/src/flash/nor/genspi.h
@@ -1,0 +1,51 @@
+
+/***************************************************************************
+ *   Copyright (C) 2016 Motorola Mobility LLC                              *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.           *
+ ***************************************************************************/
+#include "imp.h"
+#include "spi.h"
+
+struct genspi_flash_bank {
+    int probed;
+    uint32_t bank_num;
+    uint32_t reg_base;
+    uint32_t gpio_base;
+    int32_t gpio_pin;
+    const struct genspi_fops *fops;
+    const struct flash_device *dev;
+    void *driver_priv;
+};
+
+struct genspi_fops {
+    uint32_t max_data_bytes;
+    int (*spi_send_cmd)(struct flash_bank *bank, uint8_t *opcode, size_t cmd_bytes, uint8_t *data, size_t data_bytes);
+    int (*spi_init)(struct flash_bank *bank);
+};
+
+int genspi_flash_erase(struct flash_bank *bank, int first, int last);
+int genspi_flash_write(struct flash_bank *bank, const uint8_t *buffer,
+                       uint32_t offset, uint32_t count);
+int genspi_flash_read(struct flash_bank *bank, uint8_t *buffer,
+				      uint32_t offset, uint32_t count);
+int genspi_probe(struct flash_bank *bank, const struct genspi_fops *fops);
+int genspi_auto_probe(struct flash_bank *bank, const struct genspi_fops *fops);
+int genspi_flash_erase_check(struct flash_bank *bank);
+int genspi_protect_check(struct flash_bank *bank);
+int genspi_get_info(struct flash_bank *bank, char *buf, int buf_size);
+__FLASH_BANK_COMMAND(genspi_flash_bank_command);
+

--- a/src/flash/nor/hsbspi.c
+++ b/src/flash/nor/hsbspi.c
@@ -1,0 +1,505 @@
+/***************************************************************************
+ *   Copyright (C) 2016 Motorola Mobility LLC                              *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.           *
+ ***************************************************************************/
+/*
+ * SPI flash driver for use on the Motorola mods high speed bridge IC.
+ */
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+#include "genspi.h"
+#include <helper/binarybuffer.h>
+#include <target/algorithm.h>
+#include <target/armv7m.h>
+#include <target/target.h>
+
+/*
+ * ES2/ES3 HSB Registers.
+ */
+#define HSBSPI_SCM_BASE                             0x40000000
+#define HSBSPI_SCM_CLOCK_ENABLE0                    (HSBSPI_SCM_BASE+0x0300)
+#define HSBSPI_SCM_CLOCK_ENABLE0_SPI_SCLK           (1<<24)
+#define HSBSPI_SCM_CLOCK_ENABLE0_SPI_PCLK           (1<<23)
+
+#define HSBSPI_SCM_PINSHARE                         (HSBSPI_SCM_BASE+0x0800)
+#define HSBSPI_SCM_PINSHARE_SPI_DATA_GPIO           (1<<6)
+#define HSBSPI_SCM_PINSHARE_SPI_CS0_GPIO            (1<<7)
+
+#define HSBSPI_GPIO_BASE                            0x40003000
+#define HSBSPI_GPIO_ODATASET_OFS                    0x0008
+#define HSBSPI_GPIO_ODATACLR_OFS                    0x000C
+#define HSBSPI_GPIO_DIROUT_OFS                      0x0014
+#define HSBSPI_GPIO_DIRIN_OFS                       0x0018
+
+#define HSBSPI_GPIO_SPI_MOSI                        (1<<13)
+#define HSBSPI_GPIO_SPI_MISO                        (1<<14)
+#define HSBSPI_GPIO_SPI_CS0                         (1<<15)
+
+/* ES3 SPI Registers. */
+#define HSBSPI_CTRL0                                0x0000
+#define HSBSPI_CTRL0_DFS32_POS                      16
+#define HSBSPI_CTRL0_DFS32_MSK                      (0x1f<<HSBSPI_CTRL0_DFS32_POS)
+#define HSBSPI_CTRL0_CFS_POS                        12
+#define HSBSPI_CTRL0_CFS_MSK                        (0x0f<<HSBSPI_CTRL0_CFS_POS)
+#define HSBSPI_CTRL0_TMOD_POS                       8
+#define HSBSPI_CTRL0_TMOD_MSK                       (0x03<<HSBSPI_CTRL0_TMOD_POS)
+#define HSBSPI_CTRL0_TMOD_TX_RX                     (0x00<<HSBSPI_CTRL0_TMOD_POS)
+#define HSBSPI_CTRL0_SCPOL_POS                      7
+#define HSBSPI_CTRL0_SCPOL_MSK                      (0x01<<HSBSPI_CTRL0_SCPOL_POS)
+#define HSBSPI_CTRL0_SCPH_POS                       6
+#define HSBSPI_CTRL0_SCPH_MSK                       (0x01<<HSBSPI_CTRL0_SCPH_POS)
+#define HSBSPI_CTRL0_FRF_POS                        4
+#define HSBSPI_CTRL0_FRF_MSK                        (0x03<<HSBSPI_CTRL0_FRF_POS)
+#define HSBSPI_CTRL0_FRF_MOT                        (0x02<<HSBSPI_CTRL0_FRF_POS)
+
+#define HSBSPI_SSIENR                               0x0008
+#define HSBSPI_SSIENR_SSI_EN_POS                    0
+#define HSBSPI_SSIENR_SSI_EN_MSK                    (1<<HSBSPI_SSIENR_SSI_EN_POS)
+
+#define HSBSPI_SER                                  0x0010
+#define HSBSPI_SER_POS                              0
+#define HSBSPI_SER_MSK                              (0x3<<HSBSPI_SER_POS)
+
+#define HSBSPI_BAUDR                                0x0014
+#define HSBSPI_BAUDR_POS                            0
+#define HSBSPI_BAUDR_MSK                            (0xffff<<HSBSPI_BAUDR_POS)
+
+#define HSBSPI_SR                                   0x0028
+#define HSBSPI_SR_DCOL_POS                          6
+#define HSBSPI_SR_DCOL_MSK                          (0x01<<HSBSPI_SR_DCOL_POS)
+#define HSBSPI_SR_RFF_POS                           4
+#define HSBSPI_SR_RFF_MSK                           (0x01<<HSBSPI_SR_RFF_POS)
+#define HSBSPI_SR_RFNE_POS                          3
+#define HSBSPI_SR_RFNE_MSK                          (0x01<<HSBSPI_SR_RFNE_POS)
+#define HSBSPI_SR_TFE_POS                           2
+#define HSBSPI_SR_TFE_MSK                           (0x01<<HSBSPI_SR_TFE_POS)
+#define HSBSPI_SR_TFNF_POS                          1
+#define HSBSPI_SR_TFNF_MSK                          (0x01<<HSBSPI_SR_TFNF_POS)
+#define HSBSPI_SR_BUSY_POS                          0
+#define HSBSPI_SR_BUSY_MSK                          (0x01<<HSBSPI_SR_BUSY_POS)
+
+#define HSBSPI_DR0                                  0x0060
+#define HSBSPI_DR0_POS                              0
+#define HSBSPI_DR0_MSK                              (0xffffffff<<HSBSPI_DR0_POS)
+
+#define HSBSPI_CMD_SZ                               6
+#define HSBSPI_DATA_SZ                              4096
+
+static const uint8_t hsbspi_flash_code[] =
+{
+                               /* hsbspi_flash:                                                 */
+    0x01, 0xb3,                /*    0:   b301        cbz r1, 44 <done>                         */
+    0xdf, 0xf8, 0x3c, 0x60,    /*    2:   f8df 603c   ldr.w   r6, [pc, #60]   ; 40 <spi_ctrl_0> */
+    0x16, 0x60,                /*    6:   6016        str r6, [r2, #0]                          */
+    0x4f, 0xf0, 0x00, 0x06,    /*    8:   f04f 0600   mov.w   r6, #0                            */
+    0xd6, 0x62,                /*    c:   62d6        str r6, [r2, #44]   ; 0x2c                */
+    0x96, 0x68,                /*    e:   6896        ldr r6, [r2, #8]                          */
+    0x46, 0xf0, 0x01, 0x06,    /*   10:   f046 0601   orr.w   r6, r6, #1                        */
+    0x96, 0x60,                /*   14:   6096        str r6, [r2, #8]                          */
+    0x04, 0x46,                /*   16:   4604        mov r4, r0                                */
+    0x0d, 0x46,                /*   18:   460d        mov r5, r1                                */
+                               /* copy_tx_bytes:                                                */
+    0x39, 0xb1,                /*   1a:   b139        cbz r1, 2c <copy_rx_bytes>                */
+    0x96, 0x6a,                /*   1c:   6a96        ldr r6, [r2, #40]   ; 0x28                */
+    0x16, 0xf0, 0x02, 0x0f,    /*   1e:   f016 0f02   tst.w   r6, #2                            */
+    0x1e, 0xbf,                /*   22:   bf1e        ittt    ne                                */
+    0x10, 0xf8, 0x01, 0x7b,    /*   24:   f810 7b01   ldrbne.w    r7, [r0], #1                  */
+    0x17, 0x66,                /*   28:   6617        strne   r7, [r2, #96]   ; 0x60            */
+    0x01, 0x39,                /*   2a:   3901        subne   r1, #1                            */
+                               /* copy_rx_bytes:                                                */
+    0x55, 0xb1,                /*   2c:   b155        cbz r5, 44 <done>                         */
+    0x96, 0x6a,                /*   2e:   6a96        ldr r6, [r2, #40]   ; 0x28                */
+    0x16, 0xf0, 0x08, 0x0f,    /*   30:   f016 0f08   tst.w   r6, #8                            */
+    0x1e, 0xbf,                /*   34:   bf1e        ittt    ne                                */
+    0x17, 0x6e,                /*   36:   6e17        ldrne   r7, [r2, #96]   ; 0x60            */
+    0x04, 0xf8, 0x01, 0x7b,    /*   38:   f804 7b01   strbne.w    r7, [r4], #1                  */
+    0x01, 0x3d,                /*   3c:   3d01        subne   r5, #1                            */
+    0xec, 0xe7,                /*   3e:   e7ec        b.n 1a <copy_tx_bytes>                    */
+                               /* spi_ctrl_0:                                                   */
+    0x00, 0x00, 0x07, 0x00,    /*   40:   00070000    .word   0x00070000                        */
+                               /* done:                                                         */
+    0x97, 0x68,                /*   44:   6897        ldr r7, [r2, #8]                          */
+    0x27, 0xf0, 0x01, 0x07,    /*   46:   f027 0701   bic.w   r7, r7, #1                        */
+    0x97, 0x60,                /*   4a:   6097        str r7, [r2, #8]                          */
+    0x00, 0xbe,                /*   4c:   be00        bkpt    0x0000                            */
+};
+
+struct hsbspi_algo_s
+{
+    struct working_area *buffer;
+    bool buffer_allocated;
+    struct working_area *code;
+    bool code_allocated;
+    struct reg_param reg_params[3];
+    struct armv7m_algorithm armv7m_info;
+};
+
+static int hsbspi_cs(struct flash_bank *bank, bool enable)
+{
+    struct genspi_flash_bank *genspi_info = bank->driver_priv;
+    uint32_t regofs;
+    int retval = ERROR_OK;
+
+    /* Toggle the chip select only if a GPIO chip select address is setup. */
+    if (genspi_info->gpio_pin >= 0) {
+        /* Active low chip select, the standard for most SPI flash parts. */
+        regofs = HSBSPI_GPIO_ODATASET_OFS;
+        if (enable) {
+            regofs = HSBSPI_GPIO_ODATACLR_OFS;
+        }
+        LOG_DEBUG("Setting chip select with %08x = %08x",
+                  genspi_info->gpio_base+regofs,
+                  1 << genspi_info->gpio_pin);
+        retval = target_write_u32(bank->target,
+                                  genspi_info->gpio_base+regofs,
+                                  1 << genspi_info->gpio_pin);
+        if (retval != ERROR_OK) {
+            LOG_ERROR("Unable to %s SPI chip select.\n", enable ? "enable" : "disable");
+        }
+    }
+    return retval;
+}
+
+static void hsbspi_code_working_area_freed(struct target *target, struct working_area *wa, void *cb_data)
+{
+    struct flash_bank *bank = (struct flash_bank *)cb_data;
+    struct genspi_flash_bank *genspi_info = bank->driver_priv;
+    struct hsbspi_algo_s *hsbspi_algo = genspi_info->driver_priv;
+
+    destroy_reg_param(&hsbspi_algo->reg_params[0]);
+    destroy_reg_param(&hsbspi_algo->reg_params[1]);
+    destroy_reg_param(&hsbspi_algo->reg_params[2]);
+    hsbspi_algo->code_allocated = false;
+}
+
+static void hsbspi_buffer_working_area_freed(struct target *target, struct working_area *wa, void *cb_data)
+{
+    struct flash_bank *bank = (struct flash_bank *)cb_data;
+    struct genspi_flash_bank *genspi_info = bank->driver_priv;
+    struct hsbspi_algo_s *hsbspi_algo = genspi_info->driver_priv;
+
+    hsbspi_algo->buffer_allocated = false;
+}
+
+static int hsbspi_alloc_wa(struct flash_bank *bank)
+{
+    struct target *target = bank->target;
+    struct genspi_flash_bank *genspi_info = bank->driver_priv;
+    struct hsbspi_algo_s *hsbspi_algo = genspi_info->driver_priv;
+    uint32_t tmp_reg;
+    int retval;
+
+    if (hsbspi_algo->code_allocated == false) {
+        /*
+         * Get the working areas needed for the algorithm.  This assumes that
+         * probe will be called once per halt.
+         */
+        if (target_alloc_working_area_cb(target,
+                                         sizeof(hsbspi_flash_code),
+                                         hsbspi_code_working_area_freed,
+                                         bank,
+                                         &hsbspi_algo->code) != ERROR_OK) {
+            LOG_ERROR("A working area of at least %zu bytes is required for flash operation.",
+                      sizeof(hsbspi_flash_code)+HSBSPI_CMD_SZ+HSBSPI_DATA_SZ);
+            return ERROR_TARGET_RESOURCE_NOT_AVAILABLE;
+        }
+        hsbspi_algo->code_allocated = true;
+        retval = target_write_buffer(target, hsbspi_algo->code->address,
+                                     sizeof(hsbspi_flash_code),
+                                     hsbspi_flash_code);
+
+        init_reg_param(&hsbspi_algo->reg_params[0], "r0", 32, PARAM_IN);     /* buffer address */
+        init_reg_param(&hsbspi_algo->reg_params[1], "r1", 32, PARAM_IN);     /* size in bytes */
+        init_reg_param(&hsbspi_algo->reg_params[2], "r2", 32, PARAM_IN);     /* SPI register base address */
+
+        if (retval != ERROR_OK) {
+            LOG_ERROR("Unable to download flash code to working area.");
+            target_free_working_area(target, hsbspi_algo->code);
+            return retval;
+        }
+    }
+
+    if (hsbspi_algo->buffer_allocated == false) {
+        if (target_alloc_working_area_cb(target,
+                                         HSBSPI_CMD_SZ+HSBSPI_DATA_SZ,
+                                         hsbspi_buffer_working_area_freed,
+                                         bank,
+                                         &hsbspi_algo->buffer) != ERROR_OK) {
+            LOG_ERROR("A working area of at least %zu bytes is required for flash operation.",
+                      sizeof(hsbspi_flash_code)+HSBSPI_CMD_SZ+HSBSPI_DATA_SZ);
+            target_free_working_area(target, hsbspi_algo->code);
+            return ERROR_TARGET_RESOURCE_NOT_AVAILABLE;
+        }
+        hsbspi_algo->buffer_allocated = true;
+        /* Setup the clock. */
+        retval = target_read_u32(target, HSBSPI_SCM_CLOCK_ENABLE0, &tmp_reg);
+        if (retval != ERROR_OK) {
+            return retval;
+        }
+        tmp_reg |= HSBSPI_SCM_CLOCK_ENABLE0_SPI_SCLK | HSBSPI_SCM_CLOCK_ENABLE0_SPI_PCLK;
+        retval = target_write_u32(target, HSBSPI_SCM_CLOCK_ENABLE0, tmp_reg);
+        if (retval != ERROR_OK) {
+            return retval;
+        }
+
+        /* Set the SPI rate to the max and start the clock. */
+        retval = target_write_u32(target, genspi_info->reg_base+HSBSPI_BAUDR, 2);
+        if (retval != ERROR_OK) {
+            return retval;
+        }
+
+        /* Set the chip select. */
+        retval = target_write_u32(target, genspi_info->reg_base+HSBSPI_SER, 1);
+        if (retval != ERROR_OK) {
+            return retval;
+        }
+
+        /* Make sure the pins are configured correctly. */
+        retval = target_read_u32(target, HSBSPI_SCM_PINSHARE, &tmp_reg);
+        if (retval != ERROR_OK) {
+            return retval;
+        }
+        if (genspi_info->gpio_pin >= 0) {
+            tmp_reg &= ~(HSBSPI_SCM_PINSHARE_SPI_DATA_GPIO);
+            tmp_reg |= HSBSPI_SCM_PINSHARE_SPI_CS0_GPIO;
+        }
+        else {
+            tmp_reg &= ~(HSBSPI_SCM_PINSHARE_SPI_DATA_GPIO | HSBSPI_SCM_PINSHARE_SPI_CS0_GPIO);
+        }
+        retval = target_write_u32(target, HSBSPI_SCM_PINSHARE, tmp_reg);
+        if (retval != ERROR_OK) {
+            return retval;
+        }
+
+        /* Set the chip select to high to disable the part. */
+        retval = hsbspi_cs(bank, false);
+        if (retval != ERROR_OK) {
+            return retval;
+        }
+
+        /*
+         * Setup the GPIO as inputs or outputs:
+         *   GPIO13  SPI Data Out
+         *   GPIO14  SPI Data In
+         *   GPIO15  SPI CS
+         * SPICLK is not shared with a GPIO.
+         */
+        retval = target_write_u32(target,
+                                  genspi_info->gpio_base+HSBSPI_GPIO_DIROUT_OFS,
+                                  HSBSPI_GPIO_SPI_MOSI | HSBSPI_GPIO_SPI_CS0);
+        if (retval != ERROR_OK) {
+            return retval;
+        }
+        retval = target_write_u32(target,
+                                  genspi_info->gpio_base+HSBSPI_GPIO_DIRIN_OFS,
+                                  HSBSPI_GPIO_SPI_MISO);
+        if (retval != ERROR_OK) {
+            return retval;
+        }
+    }
+    return retval;
+}
+
+static int hsbspi_send_cmd(struct flash_bank *bank,
+                           uint8_t *cmd,
+                           size_t cmd_bytes,
+                           uint8_t *data,
+                           size_t data_bytes)
+{
+    struct genspi_flash_bank *genspi_info = bank->driver_priv;
+    struct hsbspi_algo_s *hsbspi_algo = genspi_info->driver_priv;
+    int retval;
+#if defined(DEBUG_IO)
+    uint8_t *buf;
+    unsigned int i;
+    char hexstr[12+3*16+1];
+    char alpstr[16+1];
+#endif
+
+    if (cmd_bytes > HSBSPI_CMD_SZ) {
+        LOG_ERROR("Too many command bytes (%zu) for TSB SPI.", cmd_bytes);
+        return ERROR_BUF_TOO_SMALL;
+    }
+    if (data_bytes > HSBSPI_DATA_SZ) {
+        LOG_ERROR("Too many data bytes (%zu) for TSB SPI.", data_bytes);
+        return ERROR_BUF_TOO_SMALL;
+    }
+
+    retval = hsbspi_alloc_wa(bank);
+    if (retval != ERROR_OK) {
+        LOG_ERROR("Unable to allocate working areas needed for SPI.");
+        return retval;
+    }
+	hsbspi_algo->armv7m_info.common_magic = ARMV7M_COMMON_MAGIC;
+	hsbspi_algo->armv7m_info.core_mode = ARM_MODE_THREAD;
+
+	buf_set_u32(hsbspi_algo->reg_params[0].value, 0, 32, hsbspi_algo->buffer->address);
+	buf_set_u32(hsbspi_algo->reg_params[1].value, 0, 32, cmd_bytes+data_bytes);
+	buf_set_u32(hsbspi_algo->reg_params[2].value, 0, 32, genspi_info->reg_base);
+
+    /* Copy the command into the buffer. */
+    if ((cmd_bytes > 0) && (cmd != NULL)) {
+        retval = target_write_buffer(bank->target,
+                                     hsbspi_algo->buffer->address,
+                                     cmd_bytes,
+                                     cmd);
+        if (retval != ERROR_OK) {
+            return retval;
+        }
+    }
+
+    /* Copy the data into the buffer. */
+    if ((data_bytes > 0) && (data != NULL)) {
+        retval = target_write_buffer(bank->target,
+                                     hsbspi_algo->buffer->address+cmd_bytes,
+                                     data_bytes,
+                                     data);
+        if (retval != ERROR_OK) {
+            return retval;
+        }
+    }
+
+#if defined(DEBUG_IO)
+    /* DEBUG: Read the data back and display it. */
+    buf = (uint8_t *)malloc(data_bytes+cmd_bytes);
+    target_read_buffer(bank->target, hsbspi_algo->buffer->address, cmd_bytes+data_bytes, buf);
+    for (i = 0; i < cmd_bytes+data_bytes; i++) {
+        if ((i % 16) == 0) {
+            sprintf(hexstr, "w %08x: ", hsbspi_algo->buffer->address+i);
+            alpstr[0] = '\0';
+        }
+        sprintf(hexstr, "%s %02x", hexstr, buf[i]);
+        sprintf(alpstr, "%s%c", alpstr, isprint(buf[i]) ? buf[i] : '.');
+        if (((i & 0xf) == 0xf) || (i == cmd_bytes+data_bytes-1)) {
+            LOG_DEBUG("%s %s", hexstr, alpstr);
+        }
+    }
+#endif
+
+    /* Enable the chip select. */
+    retval = hsbspi_cs(bank, true);
+    if (retval != ERROR_OK) {
+        return retval;
+    }
+
+    /* Send the data. */
+    LOG_DEBUG("Running flash algorithm.");
+    retval = target_run_algorithm(bank->target,
+                                  0,
+                                  NULL,
+                                  ARRAY_SIZE(hsbspi_algo->reg_params),
+                                  hsbspi_algo->reg_params,
+                                  hsbspi_algo->code->address,
+                                  hsbspi_algo->code->address+sizeof(hsbspi_flash_code)-2,
+                                  1000,
+                                  &hsbspi_algo->armv7m_info);
+    LOG_DEBUG("Flash algorithm exited.");
+    if (retval != ERROR_OK) {
+        LOG_ERROR("Error executing flash command algorithm.");
+        return retval;
+    }
+
+    /* Disable the chip select. */
+    retval = hsbspi_cs(bank, false);
+    if (retval != ERROR_OK) {
+        return retval;
+    }
+
+#if defined(DEBUG_IO)
+    /* DEBUG: Read the data back and display it. */
+    target_read_buffer(bank->target, hsbspi_algo->buffer->address, cmd_bytes+data_bytes, buf);
+    hexstr[0] = '\0';
+    alpstr[0] = '\0';
+    for (i = 0; i < cmd_bytes+data_bytes; i++) {
+        if ((i % 16) == 0) {
+            sprintf(hexstr, "r %08x: ", hsbspi_algo->buffer->address+i);
+            alpstr[0] = '\0';
+        }
+        sprintf(hexstr, "%s %02x", hexstr, buf[i]);
+        sprintf(alpstr, "%s%c", alpstr, isprint(buf[i]) ? buf[i] : '.');
+        if (((i & 0xf) == 0xf) || (i == cmd_bytes+data_bytes-1)) {
+            LOG_DEBUG("%s %s", hexstr, alpstr);
+        }
+    }
+    free(buf);
+#endif
+
+    /* Copy the command response. */
+    if ((cmd_bytes > 0) && (cmd != NULL)) {
+        retval = target_read_buffer(bank->target,
+                                    hsbspi_algo->buffer->address,
+                                    cmd_bytes,
+                                    cmd);
+        if (retval != ERROR_OK) {
+            return retval;
+        }
+    }
+    /* Copy the data response. */
+    if ((data_bytes > 0) && (data != NULL)) {
+        retval = target_read_buffer(bank->target,
+                                    hsbspi_algo->buffer->address+cmd_bytes,
+                                    data_bytes,
+                                    data);
+    }
+    return retval;
+}
+
+static int hsbspi_init(struct flash_bank *bank)
+{
+    struct genspi_flash_bank *genspi_info = bank->driver_priv;
+
+    genspi_info->driver_priv = malloc(sizeof(struct hsbspi_algo_s));
+    if (genspi_info->driver_priv == NULL) {
+        return(ERROR_FAIL);
+    }
+    memset(genspi_info->driver_priv, 0, sizeof(struct hsbspi_algo_s));
+    return ERROR_OK;
+}
+
+static const struct genspi_fops hsbspi_fops =
+{
+    HSBSPI_DATA_SZ,
+    hsbspi_send_cmd,
+    hsbspi_init
+};
+
+static int hsbspi_probe(struct flash_bank *bank)
+{
+    return genspi_probe(bank, &hsbspi_fops);
+}
+
+static int hsbspi_auto_probe(struct flash_bank *bank)
+{
+    return genspi_auto_probe(bank, &hsbspi_fops);
+}
+
+struct flash_driver hsbspi_flash = {
+    .name = "hsbspi",
+    .usage = "<spi_reg_base_address> [chip_select_gpio_base chip_select_pin]",
+    .flash_bank_command = genspi_flash_bank_command,
+    .erase = genspi_flash_erase,
+    .protect = NULL,
+    .write = genspi_flash_write,
+    .read = genspi_flash_read,
+    .probe = hsbspi_probe,
+    .auto_probe = hsbspi_auto_probe,
+    .erase_check = genspi_flash_erase_check,
+    .protect_check = genspi_protect_check,
+    .info = genspi_get_info,
+};

--- a/src/flash/nor/spi.c
+++ b/src/flash/nor/spi.c
@@ -5,6 +5,8 @@
  *   Copyright (C) 2010 by Antonio Borneo                                  *
  *   borneo.antonio@gmail.com                                              *
  *                                                                         *
+ *   Copyright (C) 2016 Motorola Mobility LLC                              *
+ *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
  *   the Free Software Foundation; either version 2 of the License, or     *
@@ -74,6 +76,8 @@ const struct flash_device flash_devices[] = {
 	FLASH_ID("win w25q80bv",   0xd8, 0xc7, 0x001440ef, 0x100, 0x10000, 0x100000),
 	FLASH_ID("win w25q32fv",   0xd8, 0xc7, 0x001640ef, 0x100, 0x10000, 0x400000),
 	FLASH_ID("win w25q32dw",   0xd8, 0xc7, 0x001660ef, 0x100, 0x10000, 0x400000),
+	FLASH_ID("win w25q40bw",   0x20, 0xc7, 0x001350ef, 0x100, 0x1000,  0x800000),
+	FLASH_ID("win w25q40ew",   0x20, 0xc7, 0x001360ef, 0x100, 0x1000,  0x800000),
 	FLASH_ID("win w25q64cv",   0xd8, 0xc7, 0x001740ef, 0x100, 0x10000, 0x800000),
 	FLASH_ID("win w25q128fv",  0xd8, 0xc7, 0x001840ef, 0x100, 0x10000, 0x1000000),
 	FLASH_ID("gd gd25q20",     0x20, 0xc7, 0x00c84012, 0x100, 0x1000,  0x80000),

--- a/src/flash/nor/spi.h
+++ b/src/flash/nor/spi.h
@@ -5,6 +5,8 @@
  *   Copyright (C) 2010 by Antonio Borneo                                  *
  *   borneo.antonio@gmail.com                                              *
  *                                                                         *
+ *   Copyright (C) 2016 Motorola Mobility LLC                              *
+ *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
  *   the Free Software Foundation; either version 2 of the License, or     *
@@ -53,6 +55,7 @@ extern const struct flash_device flash_devices[];
 #define SPIFLASH_READ_ID		0x9F /* Read Flash Identification */
 #define SPIFLASH_READ_STATUS	0x05 /* Read Status Register */
 #define SPIFLASH_WRITE_ENABLE	0x06 /* Write Enable */
+#define SPIFLASH_WRITE_DISABLE  0x04 /* Write Disable */
 #define SPIFLASH_PAGE_PROGRAM	0x02 /* Page Program */
 #define SPIFLASH_FAST_READ		0x0B /* Fast Read */
 #define SPIFLASH_READ			0x03 /* Normal Read */

--- a/src/flash/nor/stm32spi.c
+++ b/src/flash/nor/stm32spi.c
@@ -1,0 +1,425 @@
+/***************************************************************************
+ *   Copyright (C) 2016 Motorola Mobility LLC                              *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.           *
+ ***************************************************************************/
+/*
+ * SPI flash driver for use on the STM32 micro controllers.
+ *
+ * Before this code can be used the GPIO and clock clock tree must be setup.
+ * Due to the differences between different versions of the STM32 parts it is
+ * assumed the GPIO and clock are already setup and the clock does not exceed
+ * 96MHz.  While the parts differ each seems to have an RCC enable bit which
+ * must be enabled before using this code.  See the config file
+ * mot_mdk_muc_common.cfg for an example.
+ */
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+#include "genspi.h"
+#include <helper/binarybuffer.h>
+#include <target/algorithm.h>
+#include <target/armv7m.h>
+#include <target/target.h>
+
+#define STM32SPI_CR1_OFS      0x00
+#define STM32SPI_CR1_SSM      (1<<9)
+#define STM32SPI_CR1_SSI      (1<<8)
+#define STM32SPI_CR1_SPE      (1<<6)
+#define STM32SPI_CR1_BR_POS   3
+#define STM32SPI_CR1_BR_MSK   (0x7<<STM32SPI_CR1_BR_POS)
+#define STM32SPI_CR1_MSTR     (1<<2)
+#define STM32SPI_CR1_CPOL     (1<<1)
+#define STM32SPI_CR1_CPHA     (1<<0)
+
+#define STM32SPI_CR2_OFS      0x04
+#define STM32SPI_CR2_FRXTH    (1<<12)
+#define STM32SPI_CR2_DS_MSK   (0xf<<8)
+#define STM32SPI_CR2_DS_8BIT  (0x7<<8)
+#define STM32SPI_CR2_FRF      (1<<4)
+#define STM32SPI_CR2_SSOE     (1<<2)
+
+#define STM32SPI_SR_OFS       0x08
+#define STM32SPI_SR_FTLVL_MSK (0x3<<11)
+#define STM32SPI_SR_FRLVL_MSK (0x3<<9)
+#define STM32SPI_SR_BSY       (1<<7)
+#define STM32SPI_SR_TXE       (1<<1)
+#define STM32SPI_SR_RXNE      (1<<0)
+
+#define STM32SPI_DR_OFS       0x0c
+
+#define STM32GPIO_BSRR_OFS    0x18
+
+#define DEBUG_IO              1
+
+#define STM32SPI_CMD_SZ       6
+#define STM32SPI_DATA_SZ      4096
+
+/* See contrib/loaders/flash/stm32spi.S. */
+static const uint8_t stm32spi_flash_code[] =
+{
+                               /* stm32spi_flash:                                */
+    0xc1, 0xb1,                /*    0:   b1c1        cbz r1, 34 <done>          */
+    0x16, 0x88,                /*    2:   8816        ldrh    r6, [r2, #0]       */
+    0x46, 0xf0, 0x40, 0x06,    /*    4:   f046 0640   orr.w   r6, r6, #64 ; 0x40 */
+    0x16, 0x80,                /*    8:   8016        strh    r6, [r2, #0]       */
+    0x04, 0x46,                /*    a:   4604        mov r4, r0                 */
+    0x0d, 0x46,                /*    c:   460d        mov r5, r1                 */
+                               /* copy_tx_bytes:                                 */
+    0x39, 0xb1,                /*    e:   b139        cbz r1, 20 <copy_rx_bytes> */
+    0x16, 0x89,                /*   10:   8916        ldrh    r6, [r2, #8]       */
+    0x16, 0xf0, 0x02, 0x0f,    /*   12:   f016 0f02   tst.w   r6, #2             */
+    0x1e, 0xbf,                /*   16:   bf1e        ittt    ne                 */
+    0x10, 0xf8, 0x01, 0x7b,    /*   18:   f810 7b01   ldrbne.w    r7, [r0], #1   */
+    0x17, 0x73,                /*   1c:   7317        strbne  r7, [r2, #12]      */
+    0x01, 0x39,                /*   1e:   3901        subne   r1, #1             */
+                               /* copy_rx_bytes:                                 */
+    0x45, 0xb1,                /*   20:   b145        cbz r5, 34 <done>          */
+    0x16, 0x89,                /*   22:   8916        ldrh    r6, [r2, #8]       */
+    0x16, 0xf0, 0x01, 0x0f,    /*   24:   f016 0f01   tst.w   r6, #1             */
+    0x1e, 0xbf,                /*   28:   bf1e        ittt    ne                 */
+    0x17, 0x7b,                /*   2a:   7b17        ldrbne  r7, [r2, #12]      */
+    0x04, 0xf8, 0x01, 0x7b,    /*   2c:   f804 7b01   strbne.w    r7, [r4], #1   */
+    0x01, 0x3d,                /*   30:   3d01        subne   r5, #1             */
+    0xec, 0xe7,                /*   32:   e7ec        b.n e <copy_tx_bytes>      */
+                               /* done:                                          */
+    0x17, 0x89,                /*   34:   8917        ldrh    r7, [r2, #8]       */
+    0x17, 0xf0, 0x80, 0x0f,    /*   36:   f017 0f80   tst.w   r7, #128    ; 0x80 */
+    0xfb, 0xd1,                /*   3a:   d1fb        bne.n   34 <done>          */
+    0x17, 0x88,                /*   3c:   8817        ldrh    r7, [r2, #0]       */
+    0x27, 0xf0, 0x40, 0x07,    /*   3e:   f027 0740   bic.w   r7, r7, #64 ; 0x40 */
+    0x17, 0x80,                /*   42:   8017        strh    r7, [r2, #0]       */
+    0x00, 0xbe,                /*   44:   be00        bkpt    0x0000             */
+};
+
+struct stm32spi_algo_s
+{
+    struct working_area *buffer;
+    bool buffer_allocated;
+    struct working_area *code;
+    bool code_allocated;
+    struct reg_param reg_params[3];
+    struct armv7m_algorithm armv7m_info;
+};
+
+static int stm32spi_cs(struct flash_bank *bank, bool enable)
+{
+    struct genspi_flash_bank *genspi_info = bank->driver_priv;
+    uint32_t tmpreg;
+    int retval = ERROR_OK;
+
+    /* Toggle the chip select only if a GPIO chip select address is setup. */
+    if (genspi_info->gpio_pin >= 0) {
+        /* Active low chip select, the standard for most SPI flash parts. */
+        tmpreg = (1 << genspi_info->gpio_pin) << (enable ? 16 : 0);
+        LOG_DEBUG("Setting chip select with %08x = %08x", genspi_info->gpio_base+STM32GPIO_BSRR_OFS, tmpreg);
+        retval = target_write_u32(bank->target, genspi_info->gpio_base+STM32GPIO_BSRR_OFS, tmpreg);
+        if (retval != ERROR_OK) {
+            LOG_ERROR("Unable to %s SPI chip select.\n", enable ? "enable" : "disable");
+        }
+    }
+    return retval;
+}
+
+static void stm32spi_code_working_area_freed(struct target *target, struct working_area *wa, void *cb_data)
+{
+    struct flash_bank *bank = (struct flash_bank *)cb_data;
+    struct genspi_flash_bank *genspi_info = bank->driver_priv;
+    struct stm32spi_algo_s *stm32spi_algo = genspi_info->driver_priv;
+
+    destroy_reg_param(&stm32spi_algo->reg_params[0]);
+    destroy_reg_param(&stm32spi_algo->reg_params[1]);
+    destroy_reg_param(&stm32spi_algo->reg_params[2]);
+    stm32spi_algo->code_allocated = false;
+}
+
+static void stm32spi_buffer_working_area_freed(struct target *target, struct working_area *wa, void *cb_data)
+{
+    struct flash_bank *bank = (struct flash_bank *)cb_data;
+    struct genspi_flash_bank *genspi_info = bank->driver_priv;
+    struct stm32spi_algo_s *stm32spi_algo = genspi_info->driver_priv;
+
+    stm32spi_algo->buffer_allocated = false;
+}
+
+static int stm32spi_allocte_wa(struct flash_bank *bank)
+{
+    struct target *target = bank->target;
+    struct genspi_flash_bank *genspi_info = bank->driver_priv;
+    struct stm32spi_algo_s *stm32spi_algo = genspi_info->driver_priv;
+    uint16_t cr1;
+    int retval = ERROR_OK;
+
+    if (stm32spi_algo == NULL) {
+        LOG_ERROR("Driver private data not allocated.");
+        return ERROR_FAIL;
+    }
+
+    if (stm32spi_algo->code_allocated == false) {
+        /*
+         * Get the working areas needed for the algorithm.  This assumes that
+         * probe will be called once per halt.
+         */
+        if (target_alloc_working_area_cb(target,
+                                        sizeof(stm32spi_flash_code),
+                                        stm32spi_code_working_area_freed,
+                                        bank,
+                                        &stm32spi_algo->code) != ERROR_OK) {
+            LOG_ERROR("A working area of at least %zu bytes is required for flash operation.",
+                    sizeof(stm32spi_flash_code)+STM32SPI_CMD_SZ+STM32SPI_DATA_SZ);
+            return ERROR_TARGET_RESOURCE_NOT_AVAILABLE;
+        }
+        stm32spi_algo->code_allocated = true;
+        retval = target_write_buffer(target, stm32spi_algo->code->address,
+                                    sizeof(stm32spi_flash_code),
+                                    stm32spi_flash_code);
+
+        init_reg_param(&stm32spi_algo->reg_params[0], "r0", 32, PARAM_IN);     /* buffer address */
+        init_reg_param(&stm32spi_algo->reg_params[1], "r1", 32, PARAM_IN);     /* size in bytes */
+        init_reg_param(&stm32spi_algo->reg_params[2], "r2", 32, PARAM_IN);     /* SPI register base address */
+
+        if (retval != ERROR_OK) {
+            LOG_ERROR("Unable to download flash code to working area.");
+            target_free_working_area(target, stm32spi_algo->code);
+            return retval;
+        }
+    }
+
+    if (stm32spi_algo->buffer_allocated == false) {
+        if (target_alloc_working_area_cb(target,
+                                        STM32SPI_CMD_SZ+STM32SPI_DATA_SZ,
+                                        stm32spi_buffer_working_area_freed,
+                                        bank,
+                                        &stm32spi_algo->buffer) != ERROR_OK) {
+            LOG_ERROR("A working area of at least %zu bytes is required for flash operation.",
+                    sizeof(stm32spi_flash_code)+STM32SPI_CMD_SZ+STM32SPI_DATA_SZ);
+            target_free_working_area(target, stm32spi_algo->code);
+            return ERROR_TARGET_RESOURCE_NOT_AVAILABLE;
+        }
+        stm32spi_algo->buffer_allocated = true;
+        /* Set up for communication with most SPI flash parts. */
+        cr1 = ((0 << STM32SPI_CR1_BR_POS) & STM32SPI_CR1_BR_MSK) | STM32SPI_CR1_MSTR;
+        if (genspi_info->gpio_pin >= 0) {
+            cr1 |= STM32SPI_CR1_SSI | STM32SPI_CR1_SSM;
+        }
+
+        retval = target_write_u16(target, genspi_info->reg_base+STM32SPI_CR1_OFS, cr1);
+        if (retval != ERROR_OK) {
+            LOG_ERROR("Unable to write to the SPI confg 1 register.");
+            return retval;
+        }
+        retval = target_write_u16(target, genspi_info->reg_base+STM32SPI_CR2_OFS,
+                                  (STM32SPI_CR2_FRXTH |
+                                   STM32SPI_CR2_DS_8BIT |
+                                   STM32SPI_CR2_SSOE));
+        if (retval != ERROR_OK) {
+            LOG_ERROR("Unable to write to the SPI confg 2 register.");
+            return retval;
+        }
+        /* Make sure the chip select starts off disabled if configured. */
+        retval = stm32spi_cs(bank, false);
+    }
+    return retval;
+}
+
+static int stm32spi_send_cmd(struct flash_bank *bank,
+                           uint8_t *cmd,
+                           size_t cmd_bytes,
+                           uint8_t *data,
+                           size_t data_bytes)
+{
+    struct genspi_flash_bank *genspi_info = bank->driver_priv;
+    struct stm32spi_algo_s *stm32spi_algo = genspi_info->driver_priv;
+    int retval;
+#if defined(DEBUG_IO)
+    uint8_t *buf;
+    unsigned int i;
+    char hexstr[12+3*16+1];
+    char alpstr[16+1];
+#endif
+
+    if (cmd_bytes > STM32SPI_CMD_SZ) {
+        LOG_ERROR("Too many command bytes (%zu) for TSB SPI.", cmd_bytes);
+        return ERROR_BUF_TOO_SMALL;
+    }
+    if (data_bytes > STM32SPI_DATA_SZ) {
+        LOG_ERROR("Too many data bytes (%zu) for TSB SPI.", data_bytes);
+        return ERROR_BUF_TOO_SMALL;
+    }
+
+    retval = stm32spi_allocte_wa(bank);
+    if (retval != ERROR_OK) {
+        LOG_ERROR("Unable to allocate working areas needed for SPI.");
+        return retval;
+    }
+	stm32spi_algo->armv7m_info.common_magic = ARMV7M_COMMON_MAGIC;
+	stm32spi_algo->armv7m_info.core_mode = ARM_MODE_THREAD;
+
+	buf_set_u32(stm32spi_algo->reg_params[0].value, 0, 32, stm32spi_algo->buffer->address);
+	buf_set_u32(stm32spi_algo->reg_params[1].value, 0, 32, cmd_bytes+data_bytes);
+	buf_set_u32(stm32spi_algo->reg_params[2].value, 0, 32, genspi_info->reg_base);
+
+    /* Copy the command into the buffer. */
+    if ((cmd_bytes > 0) && (cmd != NULL)) {
+        retval = target_write_buffer(bank->target,
+                                     stm32spi_algo->buffer->address,
+                                     cmd_bytes,
+                                     cmd);
+        if (retval != ERROR_OK) {
+            return retval;
+        }
+    }
+
+    /* Copy the data into the buffer. */
+    if ((data_bytes > 0) && (data != NULL)) {
+        retval = target_write_buffer(bank->target,
+                                     stm32spi_algo->buffer->address+cmd_bytes,
+                                     data_bytes,
+                                     data);
+        if (retval != ERROR_OK) {
+            return retval;
+        }
+    }
+
+#if defined(DEBUG_IO)
+    /* DEBUG: Read the data back and display it. */
+    buf = (uint8_t *)malloc(data_bytes+cmd_bytes);
+    target_read_buffer(bank->target, stm32spi_algo->buffer->address, cmd_bytes+data_bytes, buf);
+    for (i = 0; i < cmd_bytes+data_bytes; i++) {
+        if ((i % 16) == 0) {
+            sprintf(hexstr, "w %08x: ", stm32spi_algo->buffer->address+i);
+            alpstr[0] = '\0';
+        }
+        sprintf(hexstr, "%s %02x", hexstr, buf[i]);
+        sprintf(alpstr, "%s%c", alpstr, isprint(buf[i]) ? buf[i] : '.');
+        if (((i & 0xf) == 0xf) || (i == cmd_bytes+data_bytes-1)) {
+            LOG_DEBUG("%s %s", hexstr, alpstr);
+        }
+    }
+#endif
+
+    /* Enable the chip select if required by the config. */
+    retval = stm32spi_cs(bank, true);
+    if (retval != ERROR_OK)
+    {
+        return retval;
+    }
+    /* Send the data. */
+    LOG_DEBUG("Running flash algorithm.");
+    retval = target_run_algorithm(bank->target,
+                                  0,
+                                  NULL,
+                                  ARRAY_SIZE(stm32spi_algo->reg_params),
+                                  stm32spi_algo->reg_params,
+                                  stm32spi_algo->code->address,
+                                  stm32spi_algo->code->address+sizeof(stm32spi_flash_code)-2,
+                                  1000,
+                                  &stm32spi_algo->armv7m_info);
+    LOG_DEBUG("Flash algorithm exited.");
+    if (retval != ERROR_OK) {
+        LOG_ERROR("Error executing flash command algorithm.");
+        return retval;
+    }
+
+    retval = stm32spi_cs(bank, false);
+    if (retval != ERROR_OK)
+    {
+        return retval;
+    }
+
+#if defined(DEBUG_IO)
+    /* DEBUG: Read the data back and display it. */
+    target_read_buffer(bank->target, stm32spi_algo->buffer->address, cmd_bytes+data_bytes, buf);
+    hexstr[0] = '\0';
+    alpstr[0] = '\0';
+    for (i = 0; i < cmd_bytes+data_bytes; i++) {
+        if ((i % 16) == 0) {
+            sprintf(hexstr, "r %08x: ", stm32spi_algo->buffer->address+i);
+            alpstr[0] = '\0';
+        }
+        sprintf(hexstr, "%s %02x", hexstr, buf[i]);
+        sprintf(alpstr, "%s%c", alpstr, isprint(buf[i]) ? buf[i] : '.');
+        if (((i & 0xf) == 0xf) || (i == cmd_bytes+data_bytes-1)) {
+            LOG_DEBUG("%s %s", hexstr, alpstr);
+        }
+    }
+    free(buf);
+#endif
+
+    /* Copy the command response. */
+    if ((cmd_bytes > 0) && (cmd != NULL)) {
+        retval = target_read_buffer(bank->target,
+                                    stm32spi_algo->buffer->address,
+                                    cmd_bytes,
+                                    cmd);
+        if (retval != ERROR_OK) {
+            return retval;
+        }
+    }
+    /* Copy the data response. */
+    if ((data_bytes > 0) && (data != NULL)) {
+        retval = target_read_buffer(bank->target,
+                                    stm32spi_algo->buffer->address+cmd_bytes,
+                                    data_bytes,
+                                    data);
+    }
+    return retval;
+}
+
+static int stm32spi_init(struct flash_bank *bank)
+{
+    struct genspi_flash_bank *genspi_info = bank->driver_priv;
+
+    genspi_info->driver_priv = malloc(sizeof(struct stm32spi_algo_s));
+    if (genspi_info->driver_priv == NULL) {
+        return(ERROR_FAIL);
+    }
+    memset(genspi_info->driver_priv, 0, sizeof(struct stm32spi_algo_s));
+    return ERROR_OK;
+}
+
+static const struct genspi_fops stm32spi_fops =
+{
+    STM32SPI_DATA_SZ,
+    stm32spi_send_cmd,
+    stm32spi_init
+};
+
+static int stm32spi_probe(struct flash_bank *bank)
+{
+    return genspi_probe(bank, &stm32spi_fops);
+}
+
+static int stm32spi_auto_probe(struct flash_bank *bank)
+{
+    return genspi_auto_probe(bank, &stm32spi_fops);
+}
+
+struct flash_driver stm32spi_flash = {
+    .name = "stm32spi",
+    .usage = "<spi_reg_base_address> [chip_select_gpio_base chip_select_pin]",
+    .flash_bank_command = genspi_flash_bank_command,
+    .erase = genspi_flash_erase,
+    .protect = NULL,
+    .write = genspi_flash_write,
+    .read = genspi_flash_read,
+    .probe = stm32spi_probe,
+    .auto_probe = stm32spi_auto_probe,
+    .erase_check = genspi_flash_erase_check,
+    .protect_check = genspi_protect_check,
+    .info = genspi_get_info,
+};

--- a/src/target/target.h
+++ b/src/target/target.h
@@ -14,6 +14,8 @@
  *   Copyright (C) ST-Ericsson SA 2011                                     *
  *   michel.jaouen@stericsson.com : smp minimum support                    *
  *                                                                         *
+ *   Copyright (C) 2016 Motorola Mobility LLC                              *
+ *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
  *   the Free Software Foundation; either version 2 of the License, or     *
@@ -94,10 +96,14 @@ enum target_endianness {
 	TARGET_BIG_ENDIAN = 1, TARGET_LITTLE_ENDIAN = 2
 };
 
+struct target;
+
 struct working_area {
 	uint32_t address;
 	uint32_t size;
 	bool free;
+	void (*free_cb)(struct target *target, struct working_area *area, void *cb_data);
+	void *free_cb_data;
 	uint8_t *backup;
 	struct working_area **user;
 	struct working_area *next;
@@ -622,6 +628,15 @@ const char *target_reset_mode_name(enum target_reset_mode reset_mode);
  */
 int target_alloc_working_area(struct target *target,
 		uint32_t size, struct working_area **area);
+/*
+ * Same as target_allocate_working_area(), but when the area is freed the callback
+ * provided is called.
+ */
+int target_alloc_working_area_cb(struct target *target,
+		uint32_t size,
+		void (*free_cb)(struct target *target, struct working_area *area, void *cb_data),
+		void *free_cb_data,
+		struct working_area **area);
 /* Same as target_alloc_working_area, except that no error is logged
  * when ERROR_TARGET_RESOURCE_NOT_AVAILABLE is returned.
  *
@@ -630,6 +645,15 @@ int target_alloc_working_area(struct target *target,
  */
 int target_alloc_working_area_try(struct target *target,
 		uint32_t size, struct working_area **area);
+/*
+ * Same as target_alloc_working_area_try(), but when the area is freed the callback
+ * provided is called.
+ */
+int target_alloc_working_area_try_cb(struct target *target,
+		uint32_t size,
+		void (*free_cb)(struct target *target, struct working_area *area, void *cb_data),
+        void *free_cb_data,
+        struct working_area **area);
 int target_free_working_area(struct target *target, struct working_area *area);
 void target_free_all_working_areas(struct target *target);
 uint32_t target_get_working_area_avail(struct target *target);

--- a/tcl/board/moto_mdk_hsb.cfg
+++ b/tcl/board/moto_mdk_hsb.cfg
@@ -1,4 +1,6 @@
 #
+# Copyright (c) 2016 Motorola Mobility LLC
+#
 # Configuration file for debugging the Toshiba Bridge's internal M3 via a
 # MMI mods development kit board.
 #
@@ -14,3 +16,13 @@ source [find interface/ftdi/moto_mdk_jtag.cfg]
 adapter_khz 10000
 
 source [find chip/motorola/hsb.cfg]
+
+set _FLASHNAME $_CHIPNAME.flash
+flash bank $_FLASHNAME hsbspi 0x01000000 0x00040000 0 0 $_TARGETNAME 0x40018000 0x40003000 15
+
+init
+
+#
+# Disable the watchdog timer.
+#
+mww 0x40002040 0

--- a/tcl/board/moto_mdk_muc.cfg
+++ b/tcl/board/moto_mdk_muc.cfg
@@ -1,10 +1,7 @@
 #
+# Copyright (c) 2016 Motorola Mobility LLC
+#
 # Connect to the MuC on the Moto Mods Development kit.
 #
 source [find interface/ftdi/moto_mdk_swd.cfg]
-
-#
-# Use the lines below to connect to the STM32L476.
-#
-set WORKAREASIZE 0x2000
-source [find target/stm32l4x.cfg]
+source [find board/moto_mdk_muc_common.cfg]

--- a/tcl/board/moto_mdk_muc_common.cfg
+++ b/tcl/board/moto_mdk_muc_common.cfg
@@ -1,0 +1,304 @@
+#
+# Copyright (c) 2016 Motorola Mobility LLC
+#
+# Common defines for the normal and reset MuC configurations for the Motorola
+# mods development kit.
+#
+set HSB_SPI_FLASH_SZ        0x80000
+set HSB_SPI_FLASH_SECTOR_SZ 0x1000
+
+set GPIOA                   0x48000000
+set GPIOB                   0x48000400
+set GPIOC                   0x48000800
+set GPIOD                   0x48000c00
+set GPIOE                   0x48001000
+set GPIOF                   0x48001400
+set GPIOG                   0x48001800
+set GPIOH                   0x48001c00
+set GPIO_MODER_OFS          0x00
+set GPIO_OTYPER_OFS         0x04
+set GPIO_OSPEEDR_OFS        0x08
+set GPIO_BSRR_OFS           0x18
+set GPIOA_AFRL_OFS          0x20
+set GPIOB_AFRH_OFS          0x24
+
+set MUC_SPI_SEL_PORT        $GPIOC
+set MUC_SPI_SEL_PIN         6
+set HSB_PWR_EN_PORT         $GPIOG
+set HSB_PWR_EN_PIN          14
+set HSB_SPI_BOOT_N_PORT     $GPIOA
+set HSB_SPI_BOOT_N_PIN      8
+set HSB_WAKE_PORT           $GPIOB
+set HSB_WAKE_PIN            8
+set HSB_RESET_N_PORT        $GPIOH
+set HSB_RESET_N_PIN         1
+
+set MUC_SPI_PORT            $GPIOA
+set MUC_SPI_CS_PIN          4
+set MUC_SPI_CLK_PIN         5
+set MUC_SPI_MISO_PIN        6
+set MUC_SPI_MOSI_PIN        7
+set MUC_SPI_ALT_FCN_SPI     5
+
+#
+# Use the lines below to connect to the STM32L476.
+#
+set WORKAREASIZE            0x2000
+source [find target/stm32l4x.cfg]
+
+#
+# Setup the HSB SPI flash on SPI1 (0x40013000).  Please note to program this the
+# switch to route SPI to it must be enabled using the provided script.
+# MUC_SPI_SEL (PC6) is used for routing SPI1 to the HSB flash part.
+# HSB_PWR_EN (PG15) is used to enable power to the HSB.
+#
+# Please note the chip select is controlled using GPIO due to not being able to
+# get the hardware chip select logic to work.
+#
+flash bank $_CHIPNAME.spiflash stm32spi 0 0x00040000 0 0 $_TARGETNAME 0x40013000 $MUC_SPI_PORT $MUC_SPI_CS_PIN
+
+set GPIO_MODE_INPUT         0x0
+set GPIO_MODE_OUTPUT        0x1
+set GPIO_MODE_ALT           0x2
+set GPIO_MODE_ANALOG        0x3
+proc stm32_gpio_set_mode {port pin mode} {
+    global GPIO_MODER_OFS
+
+    mmw [expr ($port+$GPIO_MODER_OFS)] [expr ($mode<<($pin*2))] [expr (0x3<<($pin*2))]
+}
+add_usage_text stm32_gpio_set_mode "<port base address> <pin number> <mode>"
+add_help_text  stm32_gpio_set_mode "Set the pin mode to: Input (0 - GPIO_MODE_INPUT), Output (1 - GPIO_MODE_OUTPUT), Alternate Usage (2 - GPIO_MODE_ALT), Analog (3 - GPIO_MODE_ANALOG)."
+
+set GPIO_TYPE_PUSH_PULL     0
+set GPIO_TYPE_OPEN_DRAIN    1
+proc stm32_gpio_set_otype {port pin type} {
+    global GPIO_TYPE_OPEN_DRAIN
+    global GPIO_OTYPER_OFS
+
+    if { $type != 0 } {
+        set $type $GPIO_TYPE_OPEN_DRAIN
+    }
+    mmw [expr ($port+$GPIO_OTYPER_OFS)] [expr ($type<<$pin)] [expr (0x1<<$pin)]
+}
+add_usage_text stm32_gpio_set_otype "<port base address> <pin number> <type>"
+add_help_text  stm32_gpio_set_otype "Set the output drive type to: Push Pull (0 - GPIO_TYPE_PUSH_PULL), Open Drain (1 - GPIO_TYPE_OPEN_DRAIN)."
+
+set GPIO_SPEED_LOW          0
+set GPIO_SPEED_MED          1
+set GPIO_SPEED_HIGH         2
+set GPIO_SPEED_VERY_HIGH    3
+proc stm32_gpio_set_speed { port pin speed } {
+    global GPIO_OSPEEDR_OFS
+
+    mmw [expr ($port+$GPIO_OSPEEDR_OFS)] [expr ($speed<<($pin*2))] [expr (0x3<<($pin*2))]
+}
+
+set GPIO_LOW                0
+set GPIO_HIGH               1
+proc stm32_gpio_set_pin {port pin enable} {
+    global GPIO_BSRR_OFS
+
+    if { $enable != 0 } {
+        set shift 0
+    } else {
+        set shift 16
+    }
+    mww [expr ($port+$GPIO_BSRR_OFS)] [expr ((1<<$pin)<<$shift)]
+}
+add_usage_text stm32_gpio_set_pin "<port base address> <pin> <0 | 1>"
+add_help_text  stm32_gpio_set_pin "Set the pin output register to the provided value."
+
+proc stm32_gpio_set_alt_fcn { port pin function } {
+    global GPIOA_AFRL_OFS
+    global GPIOA_AFRH_OFS
+
+    set offset $GPIOA_AFRL_OFS;
+    if { $pin > 7 } {
+        set offset $GPIOA_AFRH_OFS
+        incr pin -8
+    }
+    mmw [expr ($port+$offset)] [expr (($function&0xf)<<($pin*4))] [expr (0xf<<($pin*4))]
+}
+add_usage_text stm32_gpio_set_alt_fcn "<port base address> <pin> <fcn 0-15>"
+add_help_text  stm32_gpio_set_alt_fcn "Set the alternate function for the provided port."
+
+proc stm32l4_spi1_clk_enable { } {
+    set STM32RCC_BASE              0x40021000
+    set STM32RCC_APB2ENR_OFS       0x60
+    set STM32RCC_APB2ERR_SPI1_EN   [expr (1<<12)]
+
+    set STM32RCC_APB2SMENR_OFS     0x80
+    set STM32RCC_APB2SMENR_SPI1_EN [expr (1<<12)]
+
+    mmw [expr ($STM32RCC_BASE+$STM32RCC_APB2ENR_OFS)]   $STM32RCC_APB2ERR_SPI1_EN   $STM32RCC_APB2ERR_SPI1_EN
+    mmw [expr ($STM32RCC_BASE+$STM32RCC_APB2SMENR_OFS)] $STM32RCC_APB2SMENR_SPI1_EN $STM32RCC_APB2SMENR_SPI1_EN
+}
+add_help_text stm32l4_spi1_clk_enable "Enable the SPI1 clock for STM32L4 series parts."
+
+proc hsb_reset_assert { } {
+    global HSB_RESET_N_PORT
+    global HSB_RESET_N_PIN
+    global GPIO_MODE_OUTPUT
+    global GPIO_TYPE_PUSH_PULL
+    global GPIO_LOW
+
+    stm32_gpio_set_mode  $HSB_RESET_N_PORT $HSB_RESET_N_PIN $GPIO_MODE_OUTPUT
+    stm32_gpio_set_otype $HSB_RESET_N_PORT $HSB_RESET_N_PIN $GPIO_TYPE_PUSH_PULL
+    stm32_gpio_set_pin   $HSB_RESET_N_PORT $HSB_RESET_N_PIN $GPIO_LOW
+}
+add_help_text hsb_reset_assert "Assert the reset pin on the HSB."
+
+proc hsb_reset_deassert { } {
+    global HSB_RESET_N_PORT
+    global HSB_RESET_N_PIN
+    global GPIO_MODE_OUTPUT
+    global GPIO_TYPE_PUSH_PULL
+    global GPIO_HIGH
+
+    stm32_gpio_set_mode  $HSB_RESET_N_PORT $HSB_RESET_N_PIN $GPIO_MODE_OUTPUT
+    stm32_gpio_set_otype $HSB_RESET_N_PORT $HSB_RESET_N_PIN $GPIO_TYPE_PUSH_PULL
+    stm32_gpio_set_pin   $HSB_RESET_N_PORT $HSB_RESET_N_PIN $GPIO_HIGH
+}
+add_help_text hsb_reset_deassert "Deassert the reset pin on the HSB."
+
+proc hsb_pwr_on { } {
+    global HSB_PWR_EN_PORT
+    global HSB_PWR_EN_PIN
+    global HSB_SPI_BOOT_N_PORT
+    global HSB_SPI_BOOT_N_PIN
+    global HSB_WAKE_PORT
+    global HSB_WAKE_PIN
+    global GPIO_MODE_OUTPUT
+    global GPIO_TYPE_PUSH_PULL
+    global GPIO_HIGH
+    global GPIO_LOW
+
+    hsb_reset_assert
+
+    stm32_gpio_set_mode  $HSB_PWR_EN_PORT $HSB_PWR_EN_PIN $GPIO_MODE_OUTPUT
+    stm32_gpio_set_otype $HSB_PWR_EN_PORT $HSB_PWR_EN_PIN $GPIO_TYPE_PUSH_PULL
+    stm32_gpio_set_pin   $HSB_PWR_EN_PORT $HSB_PWR_EN_PIN $GPIO_HIGH
+
+    stm32_gpio_set_mode  $HSB_SPI_BOOT_N_PORT $HSB_SPI_BOOT_N_PIN $GPIO_MODE_OUTPUT
+    stm32_gpio_set_otype $HSB_SPI_BOOT_N_PORT $HSB_SPI_BOOT_N_PIN $GPIO_TYPE_PUSH_PULL
+    stm32_gpio_set_pin   $HSB_SPI_BOOT_N_PORT $HSB_SPI_BOOT_N_PIN $GPIO_LOW
+
+    stm32_gpio_set_mode  $HSB_WAKE_PORT $HSB_WAKE_PIN $GPIO_MODE_OUTPUT
+    stm32_gpio_set_otype $HSB_WAKE_PORT $HSB_WAKE_PIN $GPIO_TYPE_PUSH_PULL
+    stm32_gpio_set_pin   $HSB_WAKE_PORT $HSB_WAKE_PIN $GPIO_HIGH
+
+    hsb_reset_deassert
+}
+add_help_text hsb_pwr_on "Power up the HSB."
+
+proc hsb_pwr_off { } {
+    global HSB_PWR_EN_PORT
+    global HSB_PWR_EN_PIN
+    global HSB_SPI_BOOT_N_PORT
+    global HSB_SPI_BOOT_N_PIN
+    global HSB_WAKE_PORT
+    global HSB_WAKE_PIN
+    global GPIO_MODE_OUTPUT
+    global GPIO_TYPE_PUSH_PULL
+    global GPIO_HIGH
+    global GPIO_LOW
+
+    hsb_reset_assert
+
+    stm32_gpio_set_mode  $HSB_WAKE_PORT $HSB_WAKE_PIN $GPIO_MODE_OUTPUT
+    stm32_gpio_set_otype $HSB_WAKE_PORT $HSB_WAKE_PIN $GPIO_TYPE_PUSH_PULL
+    stm32_gpio_set_pin   $HSB_WAKE_PORT $HSB_WAKE_PIN $GPIO_LOW
+
+    stm32_gpio_set_mode  $HSB_PWR_EN_PORT $HSB_PWR_EN_PIN $GPIO_MODE_OUTPUT
+    stm32_gpio_set_otype $HSB_PWR_EN_PORT $HSB_PWR_EN_PIN $GPIO_TYPE_PUSH_PULL
+    stm32_gpio_set_pin   $HSB_PWR_EN_PORT $HSB_PWR_EN_PIN $GPIO_LOW
+}
+add_help_text hsb_pwr_off "Power down the HSB."
+
+proc hsb_flash_enable { } {
+    global HSB_PWR_EN_PORT
+    global HSB_PWR_EN_PIN
+    global MUC_SPI_SEL_PORT
+    global MUC_SPI_SEL_PIN
+    global MUC_SPI_PORT
+    global MUC_SPI_CS_PIN
+    global MUC_SPI_CLK_PIN
+    global MUC_SPI_MISO_PIN
+    global MUC_SPI_MOSI_PIN
+    global MUC_SPI_ALT_FCN_SPI
+    global GPIO_MODE_OUTPUT
+    global GPIO_MODE_ALT
+    global GPIO_TYPE_PUSH_PULL
+    global GPIO_SPEED_VERY_HIGH
+    global GPIO_HIGH
+    global GPIO_LOW
+
+    # Power off the HSB, but leave the IO voltage on.
+    hsb_pwr_off
+    stm32_gpio_set_mode  $HSB_PWR_EN_PORT $HSB_PWR_EN_PIN $GPIO_MODE_OUTPUT
+    stm32_gpio_set_otype $HSB_PWR_EN_PORT $HSB_PWR_EN_PIN $GPIO_TYPE_PUSH_PULL
+    stm32_gpio_set_pin   $HSB_PWR_EN_PORT $HSB_PWR_EN_PIN $GPIO_HIGH
+
+    # Make sure GPIO is setup correctly for SPI1 operation.
+    stm32_gpio_set_mode    $MUC_SPI_PORT $MUC_SPI_CS_PIN   $GPIO_MODE_OUTPUT
+    # Used the two lines below if the chip select is not manually controlled.
+    #  stm32_gpio_set_mode    $MUC_SPI_PORT $MUC_SPI_CS_PIN   $GPIO_MODE_ALT
+    #  stm32_gpio_set_alt_fcn $MUC_SPI_PORT $MUC_SPI_CS_PIN   $MUC_SPI_ALT_FCN_SPI
+    stm32_gpio_set_otype   $MUC_SPI_PORT $MUC_SPI_CS_PIN   $GPIO_TYPE_PUSH_PULL
+    stm32_gpio_set_pin     $MUC_SPI_PORT $MUC_SPI_CS_PIN   $GPIO_HIGH
+    stm32_gpio_set_speed   $MUC_SPI_PORT $MUC_SPI_CS_PIN   $GPIO_SPEED_VERY_HIGH
+
+    stm32_gpio_set_mode    $MUC_SPI_PORT $MUC_SPI_CLK_PIN  $GPIO_MODE_ALT
+    stm32_gpio_set_alt_fcn $MUC_SPI_PORT $MUC_SPI_CLK_PIN  $MUC_SPI_ALT_FCN_SPI
+    stm32_gpio_set_otype   $MUC_SPI_PORT $MUC_SPI_CLK_PIN  $GPIO_TYPE_PUSH_PULL
+    stm32_gpio_set_speed   $MUC_SPI_PORT $MUC_SPI_CLK_PIN  $GPIO_SPEED_VERY_HIGH
+
+    stm32_gpio_set_mode    $MUC_SPI_PORT $MUC_SPI_MISO_PIN $GPIO_MODE_ALT
+    stm32_gpio_set_alt_fcn $MUC_SPI_PORT $MUC_SPI_MISO_PIN $MUC_SPI_ALT_FCN_SPI
+    stm32_gpio_set_speed   $MUC_SPI_PORT $MUC_SPI_MISO_PIN $GPIO_SPEED_VERY_HIGH
+
+    stm32_gpio_set_mode    $MUC_SPI_PORT $MUC_SPI_MOSI_PIN $GPIO_MODE_ALT
+    stm32_gpio_set_alt_fcn $MUC_SPI_PORT $MUC_SPI_MOSI_PIN $MUC_SPI_ALT_FCN_SPI
+    stm32_gpio_set_otype   $MUC_SPI_PORT $MUC_SPI_MOSI_PIN $GPIO_TYPE_PUSH_PULL
+    stm32_gpio_set_speed   $MUC_SPI_PORT $MUC_SPI_MOSI_PIN $GPIO_SPEED_VERY_HIGH
+
+    # Route SPI1 to the HSB SPI flash.
+    stm32_gpio_set_mode  $MUC_SPI_SEL_PORT $MUC_SPI_SEL_PIN $GPIO_MODE_OUTPUT
+    stm32_gpio_set_otype $MUC_SPI_SEL_PORT $MUC_SPI_SEL_PIN $GPIO_TYPE_PUSH_PULL
+    stm32_gpio_set_pin   $MUC_SPI_SEL_PORT $MUC_SPI_SEL_PIN $GPIO_HIGH
+
+    # Enable the SPI port
+    stm32l4_spi1_clk_enable
+}
+add_help_text hsb_enable_flash "Enable the SPI interface to the HSB SPI flash.  This must be done before accessing the SPI flash.  Please note this will power down the HSB.  The function disable_hsb_flash will not power the HSB back up.  For this use hsb_pwr_on function."
+
+proc hsb_flash_disable { } {
+    global MUC_SPI_SEL_PORT
+    global MUC_SPI_SEL_PIN
+    global GPIO_MODE_OUTPUT
+    global GPIO_TYPE_PUSH_PULL
+    global GPIO_LOW
+
+    # Do not route SPI1 to the HSB SPI flash
+    gpio_set_mode  $MUC_SPI_SEL_PORT $MUC_SPI_SEL_PIN $GPIO_MODE_OUTPUT
+    gpio_set_otype $MUC_SPI_SEL_PORT $MUC_SPI_SEL_PIN $GPIO_TYPE_PUSH_PULL
+    gpio_set_pin   $MUC_SPI_SEL_PORT $MUC_SPI_SEL_PIN $GPIO_LOW
+}
+add_help_text hsb_disable_flash "Disable the SPI interface to the HSB SPI flash.  This must be done before the HSB can be powered up."
+
+proc hsb_read_flash {filename} {
+    hsb_flash_enable
+    flash read_bank 1 $filename 0 $HSB_SPI_FLASH_SZ
+    hsb_flash_disable
+}
+add_usage_text hsb_read_flash "<filename>"
+add_help_text  hsb_read_flash "Read the contents of the HSB SPI flash into the filename provided.  This will power down the HSB and leave it powered off.  To power the HSB back up use the hsb_pwr_on function."
+
+proc hsb_program_flash {filename} {
+    hsb_flash_enable
+    flash erase_sectors 0 0 [expr($HSB_SPI_FLASH_SZ/$HSB_SPI_FLASH_SECTOR_SZ)]
+    flash write_bank 1 $filename 0
+    hsb_flash_disable
+}
+add_usage_text hsb_program_flash "<filename>"
+add_help_text  hsb_program_flash "Erase and program the provided file into the HSB SPI flash.  This will power down the HSB and leave it powered off.  To power the HSB  back up use the hsb_pwr_on function."

--- a/tcl/board/moto_mdk_muc_reset.cfg
+++ b/tcl/board/moto_mdk_muc_reset.cfg
@@ -1,10 +1,7 @@
 #
+# Copyright (c) 2016 Motorola Mobility LLC
+#
 # Connect to the MuC on the Moto Mods Development kit.
 #
 source [find interface/ftdi/moto_mdk_swd_reset.cfg]
-
-#
-# Use the lines below to connect to the STM32L476.
-#
-set WORKAREASIZE 0x2000
-source [find target/stm32l4x.cfg]
+source [find board/moto_mdk_muc_common.cfg]

--- a/tcl/chip/motorola/hsb.cfg
+++ b/tcl/chip/motorola/hsb.cfg
@@ -1,5 +1,7 @@
 #
-# The Toshiba AP Bridge chip contins a cortex M3.  This is the configuration
+# Copyright (c) 2016 Motorola Mobility LLC
+#
+# The High Speed Bridge chip contins a Cortex M3.  This is the configuration
 # file for use with it.
 #
 set _CHIPNAME APBridge
@@ -10,9 +12,3 @@ transport select jtag
 jtag newtap $_CHIPNAME cpu -irlen 4 -expected-id 0x4ba00477
 target create $_TARGETNAME cortex_m -endian little -chain-position $_TARGETNAME
 $_TARGETNAME configure -work-area-phys 0x1002e000 -work-area-size $WORKAREASIZE -work-area-backup 0
-init
-
-#
-# Disable the watchdog timer.
-#
-mww 0x40002040 0

--- a/tcl/interface/ftdi/moto_mdk_jtag.cfg
+++ b/tcl/interface/ftdi/moto_mdk_jtag.cfg
@@ -28,8 +28,7 @@ interface ftdi
 ftdi_vid_pid 0x0403 0x6011
 
 ftdi_channel 1
-ftdi_layout_init [ expr {$JTAG_TMS|$JTAG_TRST_N|$NC_5|$JTAG_RESOUT_N} ] [ expr {$JTAG_TCK|$JTAG_TDI|$JTAG_TMS|$JTAG_TRST_N|$NC_5|$JTAG_RESOUT_N} ]
-ftdi_layout_signal nTRST -data [ expr {$JTAG_TRST_N} ]
+ftdi_layout_init [expr ($JTAG_TMS|$JTAG_TRST_N|$NC_5|$JTAG_RESOUT_N)] [expr ($JTAG_TCK|$JTAG_TDI|$JTAG_TMS|$JTAG_TRST_N|$NC_5|$JTAG_RESOUT_N)]
+ftdi_layout_signal nTRST -data $JTAG_TRST_N
 
-#reset_config srst_push_pull
 reset_config trst_only

--- a/tcl/interface/ftdi/moto_mdk_swd.cfg
+++ b/tcl/interface/ftdi/moto_mdk_swd.cfg
@@ -1,4 +1,6 @@
 #
+# Copyright (c) 2016 Motorola Mobility LLC
+#
 # Motorola Mobility Mods Development Kit SWD configuration.
 #
 # The board contains an FT4232 which has the port A configured as  SWD using
@@ -14,6 +16,14 @@ transport select swd
 
 ftdi_channel 0
 
-ftdi_layout_init 0x0010 0x001b
+ftdi_layout_init 0x0010 0x005b
 ftdi_layout_signal SWD_EN   -data 0
 ftdi_layout_signal SWDIO_OE -data 0x0010
+ftdi_layout_signal nSRST    -ndata 0x0040
+
+reset_config srst_only srst_nogate srst_push_pull
+#
+# Change the line below to connect_assert_srst if you would like to keep
+# the processor in reset until the user runs the reset command.
+#
+reset_config connect_deassert_srst

--- a/tcl/interface/ftdi/moto_mdk_swd_reset.cfg
+++ b/tcl/interface/ftdi/moto_mdk_swd_reset.cfg
@@ -1,4 +1,6 @@
 #
+# Copyright (c) 2016 Motorola Mobility LLC
+#
 # Motorola Mobility Mods Development Kit SWD configuration version 2.
 #
 # The board contains an FT4232 which has the port A configured as SWD using
@@ -25,4 +27,3 @@ reset_config srst_only srst_nogate srst_push_pull
 # the processor in reset until the user runs the reset command.
 #
 reset_config connect_deassert_srst
-

--- a/tools/asm_to_c.pl
+++ b/tools/asm_to_c.pl
@@ -1,0 +1,100 @@
+#!/usr/bin/perl
+#
+# Copyright (c) 2016 Motorola Mobility LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the
+# Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Description:
+#    Converts an object file to a C uint8_t array for use in the source code.
+#
+# Usage:
+#    asm_to_c <object_file> [indent spaces]
+#
+use strict;
+use warnings;
+use Text::Tabs;
+
+my $OBJDUMP="arm-none-eabi-objdump -d";
+
+my $infile = $ARGV[0];
+if (! -e $infile)
+{
+    die "Unable to open input file $infile.\n";
+}
+
+my $indent = 4;
+if (defined $ARGV[1])
+{
+    $indent = $ARGV[1];
+}
+
+# Get an array containing the assembly code and object code.
+my @obj_code = `$OBJDUMP $infile`;
+chomp @obj_code;
+
+# Replace tabs with spaces.
+$tabstop = 4;
+my @obj_code_no_tab = expand(@obj_code);
+
+my $longest_line = 0;
+# Find the longest line for the end comment. */
+foreach my $line (@obj_code_no_tab)
+{
+    if (length $line > $longest_line)
+    {
+        $longest_line = length $line;
+    }
+}
+
+sub indent
+{
+    return " " x $indent;
+}
+
+my $comment_length = $longest_line;
+# Loop through the array parsing the lines.
+print indent() . "{\n";
+foreach my $line (@obj_code_no_tab)
+{
+    # Check for a label line in the form:
+    # 00000000 <flash_wait_busy_1-0xc>:
+    if ($line =~ /[0-9a-fA-F]+\s+\<(?<address>\S+)\>:/)
+    {
+        print indent() . "                               /* $+{address}:" . " " x ($comment_length - length $+{address}) . "*/\n";
+    }
+    # Check for a line with just data in the form:
+    #   64:	000411aa 	.word	0x000411aa
+    elsif ($line =~ /\s*[0-9a-fA-F]:\s+(?<byte_4>[0-9a-fA-F]{2})(?<byte_3>[0-9a-fA-F]{2})(?<byte_2>[0-9a-fA-F]{2})(?<byte_1>[0-9a-fA-F]{2})\s+\.word/)
+    {
+        my $code = $line . " " x ($comment_length - length $line);
+        print indent() . "    0x$+{byte_1}, 0x$+{byte_2}, 0x$+{byte_3}, 0x$+{byte_4},    /* $code */\n";
+    }
+    # Check for a line with double word data in the form:
+    # 2:	f015 4f00 	tst.w	r5, #2147483648	; 0x80000000
+    elsif ($line =~ /\s*[0-9a-fA-F]:\s+(?<byte_2>[0-9a-fA-F]{2})(?<byte_1>[0-9a-fA-F]{2})\s+(?<byte_4>[0-9a-fA-F]{2})(?<byte_3>[0-9a-fA-F]{2})\s+(?<code>.*)/)
+    {
+        my $code = $line . " " x ($comment_length - length $line);
+        print indent() . "    0x$+{byte_1}, 0x$+{byte_2}, 0x$+{byte_3}, 0x$+{byte_4},    /* $code */\n";
+    }
+    # Check for a line with a single word data in the form:
+    # 0:	695d      	ldr	r5, [r3, #20]
+    elsif ($line =~ /\s*[0-9a-fA-F]+:\s+(?<byte_2>[0-9a-fA-F]{2})(?<byte_1>[0-9a-fA-F]{2})\s+(?<code>.*)/)
+    {
+        my $code = $line . " " x ($comment_length - length $line);
+        print indent() . "    0x$+{byte_1}, 0x$+{byte_2},                /* $code */\n";
+    }
+}
+print indent() . "};\n";


### PR DESCRIPTION
This series of commits corrects a disassembler defect, enhances connection when the target is running and adds support for SPI flash from the MuC and the HSB.
