### PR TITLE
tcl: board: Fix MUC GDB connection

### DIFF
--- a/tcl/board/moto_mdk_muc_common.cfg
+++ b/tcl/board/moto_mdk_muc_common.cfg
@@ -58,7 +58,7 @@ source [find target/stm32l4x.cfg]
 # Please note the chip select is controlled using GPIO due to not being able to
 # get the hardware chip select logic to work.
 #
-flash bank $_CHIPNAME.spiflash stm32spi 0 $HSB_SPI_FLASH_SZ 0 0 $_TARGETNAME $SPI1 $MUC_SPI_PORT $MUC_SPI_CS_PIN $IWDG
+#flash bank $_CHIPNAME.spiflash stm32spi 0 $HSB_SPI_FLASH_SZ 0 0 $_TARGETNAME $SPI1 $MUC_SPI_PORT $MUC_SPI_CS_PIN $IWDG
 
 set GPIO_MODE_INPUT         0x0
 set GPIO_MODE_OUTPUT        0x1


### PR DESCRIPTION
GDB connections to the MUC were failing due to the addition of
the APBE's flash bank in moto_mdk_muc_common.cfg. Comment out
flash bank.

Signed-off-by: Mike Corrigan <corrigan@gmail.com>